### PR TITLE
Add MCP_SETUP.md with Google Stitch MCP setup instructions (Norwegian)

### DIFF
--- a/MCP_SETUP.md
+++ b/MCP_SETUP.md
@@ -1,0 +1,37 @@
+# MCP-oppsett for Google Stitch (Codex)
+
+Bruk **direkte Google Stitch MCP-endepunkt** i Codex-konfigen din.
+
+## Anbefalt (med miljøvariabel for API key)
+
+Legg API-nøkkelen i miljøet først:
+
+```bash
+export STITCH_API_KEY="<din_api_nokkel>"
+```
+
+Deretter i Codex-konfig (`~/.codex/config.toml`) kan du bruke:
+
+```toml
+[mcp_servers.stitch]
+url = "https://stitch.googleapis.com/mcp"
+
+[mcp_servers.stitch.http_headers]
+"X-Goog-Api-Key" = "${env:STITCH_API_KEY}"
+```
+
+## Hvis du vil lime inn nøkkel direkte (ikke anbefalt)
+
+```toml
+[mcp_servers.stitch]
+url = "https://stitch.googleapis.com/mcp"
+
+[mcp_servers.stitch.http_headers]
+"X-Goog-Api-Key" = "xxxxx....xxxxx"
+```
+
+## Sikkerhet
+
+- Ikke commit ekte nøkler i repo.
+- Rotér nøkkel hvis den har blitt delt i chat/logg.
+- Foretrekk alltid `${env:...}` fremfor hardkodet nøkkel.


### PR DESCRIPTION
### Motivation
- Add a short Norwegian guide to configure Codex to use the Google Stitch MCP endpoint and recommend using an environment variable for the API key to avoid hardcoding secrets.

### Description
- Introduce `MCP_SETUP.md` containing example configuration for `~/.codex/config.toml` showing how to export `STITCH_API_KEY` with `export STITCH_API_KEY="<din_api_nokkel>"`, how to set the `X-Goog-Api-Key` header, an alternative inline-key example, and basic security guidance about not committing keys.

### Testing
- No automated tests were added or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e75024a1308323aa43b7f0add1049c)