### PR TITLE
Add OpenSpec scaffolding for v2 rebuild

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.codex/skills/openspec-apply-change/SKILL.md
+++ b/.codex/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.codex/skills/openspec-archive-change/SKILL.md
+++ b/.codex/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.codex/skills/openspec-explore/SKILL.md
+++ b/.codex/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.codex/skills/openspec-propose/SKILL.md
+++ b/.codex/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/prompts/opsx-apply.prompt.md
+++ b/.github/prompts/opsx-apply.prompt.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/prompts/opsx-archive.prompt.md
+++ b/.github/prompts/opsx-archive.prompt.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/prompts/opsx-explore.prompt.md
+++ b/.github/prompts/opsx-explore.prompt.md
@@ -1,0 +1,170 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/prompts/opsx-propose.prompt.md
+++ b/.github/prompts/opsx-propose.prompt.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/skills/openspec-apply-change/SKILL.md
+++ b/.github/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/skills/openspec-archive-change/SKILL.md
+++ b/.github/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/skills/openspec-explore/SKILL.md
+++ b/.github/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/skills/openspec-propose/SKILL.md
+++ b/.github/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,31 @@ coverage/
 
 # Local Supabase config (if you're using supabase CLI)
 supabase/.temp/
+
+# OpenSpec — adapters for tools we don't use (re-runnable via `npx openspec init --tools <name>`)
+.agent/
+.amazonq/
+.augment/
+.bob/
+.cline/
+.clinerules/
+.codebuddy/
+.continue/
+.cospec/
+.crush/
+.cursor/
+.factory/
+.forge/
+.gemini/
+.iflow/
+.junie/
+.kilocode/
+.kiro/
+.lingma/
+.opencode/
+.pi/
+.qoder/
+.qwen/
+.roo/
+.trae/
+.windsurf/

--- a/openspec/_design-brief.md
+++ b/openspec/_design-brief.md
@@ -1,0 +1,167 @@
+Boligscore v2 — Design Brief
+1. Produkt-kontekst
+Boligscore er en norsk webapp (PWA) som hjelper par/familier å vurdere og sammenligne boliger strukturert. Primær use-case: man er på visning eller leser FINN-annonser, og vil at begge parter skal kunne score boligen uavhengig, se hvor de er enige/uenige, og lande på en felles total.
+
+Språk: Norsk (bokmål) i hele UI
+Primær enhet: Mobil (brukes på visning). Desktop er sekundært (hjemme, scroller FINN)
+Teknisk: React/Next.js app, men design-AI trenger ikke tenke på det — dette er ren UX/UI
+Installbar: Som PWA på mobil (hjemskjerm-ikon, fullskjerm)
+
+2. Målgruppe & tone
+Par i 25–45 år som skal kjøpe bolig sammen
+Ofte første bolig sammen; finansielt og emosjonelt viktig
+Teknisk komfortable, men ikke spesialister
+Tone: Rolig, ryddig, trygg. Ikke leken eller barnslig. Ikke kald corporate. Tenk Notion meets norsk folkelighet.
+Visuelt: Lyst tema som standard, dark mode som valg. Moderat avrundede hjørner. Myke farger. Tydelig typografi (san-serif). Plass og luft fremfor tettpakket data.
+
+3. Kjerneproblem
+Når to personer skal kjøpe bolig sammen:
+Man husker forskjellig etter visning
+Magefølelse dominerer — vanskelig å sammenligne bolig A mot B rasjonelt
+Uenighet blir krangel fordi det mangler et felles språk ("jeg synes kjøkkenet var fint" vs "nei det var dårlig")
+Ingen struktur — notater på papir, i hodet, i forskjellige apper
+
+Boligscore løser dette ved:
+Uavhengig scoring per person (ikke påvirket av partner)
+Synlig sammenligning (se hvor dere er uenige uten å krangle)
+Felles-karakter dere blir enige om etter diskusjon
+Vektet totalscore som lar dere rangere boliger mot hverandre
+
+4. Informasjonsarkitektur
+Hovednavigasjon (bunnmeny på mobil, sidemeny på desktop):
+Boliger — forsiden, liste over husholdningens boliger
+Vekter — hvor mye hvert kriterium teller
+Husstand — medlemmer og invitasjoner
+Meg — profil og innstillinger
+Øverst på hver side: Husholdning-velger (hvis brukeren er med i flere). Liten chip/dropdown som viser aktiv husholdning, f.eks. "🏠 Ine & Kanta ▾".
+
+5. Flyter
+Flyt A: Førstegangs-bruker
+Landingsside (/) — kort intro: "Score boliger sammen. Bli enige raskere." CTA: Logg inn / Registrer. Hero-bilde eller subtil illustrasjon.
+Registrer (/registrer) — e-post + passord (og magic-link-alternativ). Minimalt skjema.
+Onboarding: opprett husholdning (/app/onboarding) — ett felt: "Hva skal vi kalle husholdningen deres?" (eksempel: "Ine & Kanta" eller "Vårt boligsøk"). Etter opprettelse vises to knapper:
+Kopier invitasjonslenke (primær)
+Send via e-post (sekundær, åpner felt for e-postadresse) Forklarende tekst: "Send denne lenken til din partner for å score boliger sammen." Under: "Hopp over — legg til senere" (kan bruke appen alene først)
+Tom forside (/app) — illustrasjon + "Ingen boliger ennå. Legg til den første du så på FINN eller var på visning." Stor CTA: "+ Legg til bolig".
+
+Flyt B: Partner aksepterer invitasjon
+Klikk lenke → /invitasjon/[token] → hvis ikke logget inn, via registrering/innlogging først
+Konfirmasjons-side: "Ine har invitert deg til husholdningen 'Ine & Kanta'. Godta?" → knapp "Bli med"
+Lander på forsiden, nå delt med partner
+
+Flyt C: Legge til bolig
+Trykk FAB (floating action button) "+ Ny bolig" på forsiden
+Modal eller egen side med to tabs øverst:
+Fra FINN-lenke (default, anbefalt)
+Manuelt
+Fra FINN-lenke: input-felt ("Lim inn FINN-lenke"), parse-knapp, deretter visning av hva som ble funnet (adresse, pris, BRA, byggeår, bilde) med mulighet til å redigere. Hvis parsing feiler: tydelig melding + auto-hopp til manuelt skjema med det som lot seg hente.
+Manuelt skjema: gruppert i seksjoner
+Adresse & FINN-lenke
+Prisinfo (totalpris, omkostninger, felleskostnader)
+Størrelse (BRA, primærrom, soverom, bad)
+Basis-fakta (byggeår, boligtype, etasje)
+Status (dropdown): Favoritt / Vurderer / På visning / I budrunde / Bud inne / Kjøpt / Ikke aktuell
+"Lagre bolig" → går til boligens detaljside
+
+Flyt D: Score en bolig (uavhengig, per bruker)
+Åpne bolig fra listen → landing på Oversikt-tab (fakta + bilde + status)
+Tab-navigasjon: Oversikt / Min vurdering / Sammenligning / Kommentarer / Notater
+Min vurdering: kriterier gruppert i seksjoner:
+Bolig innvendig (kjøkken, bad, planløsning, lys og luftighet, oppbevaring, stue, balkong/terrasse)
+Beliggenhet & område (områdeinntrykk, nabolagsfølelse, offentlig transport, skoler/barnehager)
+Helhet (inntrykk på visning, potensial)
+Fakta (auto-beregnet: pris/kvm, størrelse, alder — read-only, bare vist)
+Per kriterium: label, kort beskrivelse, chip-rad 0–10 (eller slider). Tap for å velge. Autolagrer umiddelbart med subtil "lagret"-indikator.
+Mangler score? Rad vises grå med "— (ikke scoret)"-indikator. Ingen tvang, men telleren øverst viser "13 av 22 kriterier scoret".
+Notatblokk nederst per seksjon (privat) — for rask huskelapp ("kjøkkenet mangler oppvaskmaskin").
+
+Flyt E: Sammenligne og bli enige
+Åpne Sammenligning-tab — forutsetter at minst du har scoret
+Øverst: Totalscore-panel
+Stor "Felles: 78/100" (hovedtall, basert på felles-karakter × felles-vekter)
+Under: mindre "Din: 76" og "Kanta: 82" som sekundære tall
+Advarsel hvis ufullstendig: "⚠ 3 kriterier mangler score — regnes som 0 i totalen"
+Matrise (Layout A):
+Kriterium       Ine    Kanta    Snitt    Felles
+Kjøkken          7       8       7.5      [8]
+Bad              7       7       7         [7]
+Beliggenhet      6       9       7.5      [7]
+"Felles"-kolonnen er redigerbar inline (tap på tallet åpner chip-velger)
+Forhåndsutfylt med snitt som default, men begge kan justere
+Store uenigheter (|Δ| ≥ 3) markeres subtilt (f.eks. gul bakgrunn på raden)
+Rader gruppert etter seksjon (samme seksjoner som scoring)
+Ingen explicit "commit"-knapp — live lagring. Den som sist redigerte "felles" er den som står.
+
+Flyt F: Navigere listen
+Forsiden viser kort per bolig, sortert etter Felles totalscore som default
+Hver kort:
+Bilde (thumbnail, fra FINN eller upload)
+Adresse
+Pris • BRA • byggeår
+Felles: 78 • Din: 76
+Status-badge (fargekodet: favoritt=gul, vurderer=blå, på visning=lilla, i budrunde=oransje, bud inne=rød, kjøpt=grønn, ikke aktuell=grå)
+Sortering: Felles total, Pris, Nyeste først, Din score
+Filter-panel (bottom sheet på mobil, popover på desktop): status, prisspenn, BRA-spenn, område (tekstsøk)
+Søkefelt øverst for fritekst (adresse, kommentar, notat)
+
+Flyt G: Vekter
+Vekter-siden viser ett segmented control øverst: "Felles vekter" (default) / "Mine personlige vekter"
+Felles vekter: liste over alle 22 kriterier gruppert i samme seksjoner som scoring. Per kriterium: label, kort beskrivelse, slider 0–10.
+Endringer er delt — sambo ser endringen
+Live visning av hvordan totalscore påvirkes? Valgfri, kan droppes for MVP.
+Personlige vekter (valgfri): samme view, men ved siden av hver rad står husholdnings-vekten som "standard". Du kan overstyre — blank = bruk standard.
+
+Flyt H: Husstand
+Husstand-siden viser:
+Husholdningens navn (redigerbart)
+Medlemmer (liste med avatar + navn + rolle)
+Invitasjonspanel: "Kopier lenke" + "Send på e-post"
+Avanserte: forlat husholdning, slett husholdning (bare eier)
+Hvis bruker er med i flere husholdninger: bytte-pil øverst (som også vises på forsiden)
+
+Flyt I: Meg
+Profil (navn, avatar, e-post)
+Tema (lys/mørk/auto)
+Varsler (senere, PWA-push)
+Logg ut
+
+6. Sentrale UI-elementer (komponent-språk)
+Score-chip-rad: 11 chips (0 til 10) i en horisontal rad, kompakt. Valgt chip fylt i primærfarge, andre outline. Touch-vennlig (min 40×40px).
+Kort for bolig: avrundet kort, skygge, bilde øverst full-bredde eller venstre. Text-hierarki tydelig.
+Totalscore-badge: stor rund eller avrundet rektangel med tall og liten label ("Felles" / "Din").
+Status-badge: liten pill med ikon + tekst, fargekodet.
+FAB: stor rund knapp nederst høyre på forsiden (legg til bolig).
+Tabs: horisontal, underline-stil, scrollbar på mobil hvis mange.
+Seksjon-overskrifter: stor fet tekst + liten beskrivelse under.
+
+7. Mobil-først prinsipper
+All primær-interaksjon må fungere med én hånd
+Touch-mål minst 44×44px
+Ingen hover-avhengige interaksjoner
+Bunnmeny for navigasjon (tommel-rekkevidde)
+FAB for primær CTA (legg til bolig)
+Bottom sheets for filtre, modals for destruktive handlinger
+
+8. Tilgjengelighet
+Kontrastforhold AA minimum
+Ikoner always with text-label (not only icon)
+Focus-ring visible on tab-navigation
+Status not only color (also icon or text)
+
+9. Tom-tilstander
+Ingen boliger: illustrasjon + forklaring + CTA "Legg til første bolig"
+Ingen scores ennå: "Du har ikke scoret denne boligen. Start med kriteriene under."
+Partner har ikke scoret: "Venter på Kanta sin vurdering" — vis bare dine scores i compare
+Ingen husholdning: onboarding-flyt tar over
+
+10. Feil-tilstander
+FINN-import feilet: "Klarte ikke lese FINN-annonsen. Fyll inn manuelt." — skjemaet prefilles med det som gikk å hente
+Ingen nett: liten banner "Du er offline — endringer synkes når du er tilbake online" (men MVP krever nett, så bare vis feil)
+Invitasjon utløpt: "Denne lenken har utløpt. Be om en ny."
+
+11. Farger (forslag)
+Primær: rolig blå eller dempet grønn (tenk trygg/tillit)
+Status-farger: ikke for mettet — pastell-aktig
+Nøytrale: varm grå (ikke ren kald grå)
+Aksent: én enkelt aksentfarge for CTA-er
+Inspirasjon: Linear, Notion, Things 3, Arc Search.

--- a/openspec/changes/auth-onboarding/.openspec.yaml
+++ b/openspec/changes/auth-onboarding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/auth-onboarding/README.md
+++ b/openspec/changes/auth-onboarding/README.md
@@ -1,0 +1,3 @@
+# auth-onboarding
+
+Landing, register/login, household onboarding and invitation acceptance

--- a/openspec/changes/auth-onboarding/design.md
+++ b/openspec/changes/auth-onboarding/design.md
@@ -1,0 +1,98 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Context
+
+v1 has a basic Supabase email/password auth and dumps the user straight into the property list. v2 needs a public funnel (landing → register → onboarding → first invitation) and a partner-side flow (invitation acceptance). It also needs to be **agent-testable** — magic-link auth is notoriously painful in CI because it requires a working email inbox. We solve that by making **email/password the primary path** (works without email infrastructure) and using **Mailpit** in dev to capture any email-based flow without a real inbox.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Public landing page that explains the product and routes to register/login.
+- Email/password authentication as the primary auth method (always available).
+- Magic link as a secondary, optional auth method (works locally via Mailpit; in prod via Supabase built-in email).
+- First-run onboarding: create the user's first household, optionally generate an invitation link, then route to `/app`.
+- Invitation acceptance route (`/invitasjon/[token]`) that supports unauthenticated users by routing them through register/login first.
+- A `/dev/login` route gated by env var that signs in a seeded test user with one click — used by e2e tests to bypass auth flows.
+- Logout action lives only on `/app/meg`.
+
+**Non-Goals:**
+- OAuth (Google, Apple, GitHub) — out of MVP scope, can be added later as a separate change.
+- 2FA — out of scope.
+- Custom password reset UI — Supabase's default "forgot password" flow suffices in MVP.
+- Email verification gates — Supabase email confirmation is configured to OFF in dev, ON in prod with a "kontroller e-post" notice.
+- Welcome email sequences / drip campaigns.
+
+## Decisions
+
+### D1. Email/password is primary; magic link is secondary
+
+**Choice**: register/login pages show email + password form by default. A `Logg inn med e-postlenke i stedet` link reveals an alternate form (just email field). Both run via Supabase Auth.
+
+**Alternative considered**: magic-link only (passwordless).
+
+**Rationale**: passwordless is delightful when it works but failure modes (email delayed, spam folder, link expired in another browser) are devastating UX. Password gives users (and tests) a reliable fallback. We don't have to choose — Supabase supports both natively.
+
+### D2. Email/password verification flag
+
+**Choice**: in dev, `EMAIL_CONFIRM_REQUIRED = false` (sign in immediately). In prod, `EMAIL_CONFIRM_REQUIRED = true` (user must click the confirmation link in their email before logging in).
+
+**Rationale**: dev workflow needs to be fast and reliable. Prod needs to defend against bot signups. Supabase configures this per-project.
+
+### D3. Mailpit for all dev email; Resend for prod invitation emails (deferred)
+
+**Choice**: Supabase CLI's local stack ships Mailpit at `http://localhost:54324`. All Supabase-sent emails (magic link, confirmation, password reset) are captured there in dev. Invitation emails are deferred to a follow-up change (per `households` D9).
+
+**Alternative considered**: ngrok the dev environment and use a real inbox.
+
+**Rationale**: Mailpit is zero-config, zero-cost, zero-flake. The dev experience is "click the link in Mailpit's web UI". Tests poll Mailpit's HTTP API to read captured messages.
+
+### D4. Onboarding always creates a household
+
+**Choice**: after first signup, the user is routed to `/app/onboarding`. They cannot skip household creation; they can skip the **invitation** generation. If they reach `/app/*` without a household (somehow), the layout redirects them to onboarding.
+
+**Rationale**: every other capability assumes "active household exists". Defaulting to "every authenticated user has at least one household" eliminates a class of empty-state branches. The household name field accepts any non-empty string, so this never blocks a user.
+
+### D5. Post-login redirect with `next` param
+
+**Choice**: `/logg-inn` and `/registrer` both accept a `?next=<url>` query param. After successful auth, the user is redirected to `next` (validated as same-origin) or to `/app` if absent or invalid.
+
+**Rationale**: needed for the invitation-acceptance flow — when an unauthenticated user opens an invitation link, we redirect to `/logg-inn?next=/invitasjon/[token]` and bring them back after auth. Same-origin validation prevents open-redirect attacks.
+
+### D6. `/dev/login` bypass route
+
+**Choice**: `/dev/login` is implemented as a Next.js route handler. It calls `supabase.auth.signInWithPassword({ email, password })` for a seeded test user (`alice@test.local` / `test1234` or `bob@test.local`) and redirects to `/app`. Gated by `NEXT_PUBLIC_DEV_LOGIN_ENABLED === '1'`. Build-time check fails the production build if the env var is set in a prod environment.
+
+**Rationale**: e2e tests don't have time to walk through email/password forms 50 times. A one-click bypass keeps test runs fast. The build-time guard is what prevents accidental ship to prod.
+
+### D7. Logout in Meg only
+
+**Choice**: there is no "logg ut" button in the header, the bottom nav, or the household switcher. Only `/app/meg` has a logout action.
+
+**Alternative considered**: logout in a header dropdown.
+
+**Rationale**: brief implies it. Mobile screens are crowded; the user almost never wants to log out by accident. Putting logout where users go to "configure things" matches the principle.
+
+### D8. Public landing page is minimal
+
+**Choice**: simple landing — headline, sub-text, primary CTA (`Registrer`), secondary CTA (`Logg inn`), one supporting illustration or screenshot. No marketing scroll, no testimonials, no feature grid.
+
+**Rationale**: solo developer + MVP. Landing exists to (a) explain in one sentence what the product is and (b) push to register. Bigger landing pages can come once the product has stories worth telling.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Magic link emails delayed in prod, frustrating users | Email/password is always available as a fallback. Surface both clearly on the login page. |
+| `/dev/login` accidentally enabled in prod | Build-time guard fails the build if `NEXT_PUBLIC_DEV_LOGIN_ENABLED` is `1` in `process.env.VERCEL_ENV === 'production'`. CI test asserts the route 404s in prod build. |
+| Open redirect via `?next=https://evil.com` | Validate `next` is same-origin: parse as URL, check `host === window.location.host` (or use a relative-only allowlist). Reject otherwise. |
+| User signs up but never confirms email (prod) | Login page shows "kontroller e-post — vi har sendt en bekreftelseslenke" if Supabase returns the unconfirmed-email error. Resend confirmation link button. |
+| Bot signups | Supabase email confirmation in prod (D2). Add hCaptcha later if abuse occurs. |
+| Race: user opens invitation link, registers, but token expires before they accept | Token has 7-day window; registration takes seconds. Acceptable. |
+
+## Resolved Decisions
+
+### D9. Default test user credentials
+
+**Choice**: seeded test users are `alice@test.local` / `test1234` and `bob@test.local` / `test1234`. Same as listed in `conventions.md` test data.
+
+**Rationale**: predictable, documented, identical across local + e2e environments.

--- a/openspec/changes/auth-onboarding/proposal.md
+++ b/openspec/changes/auth-onboarding/proposal.md
@@ -1,0 +1,65 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Why
+
+v1 has a basic auth screen and dumps the user into the property list. v2 needs a real **funnel**: landing page that explains the product, clean register/login (with magic-link option), an onboarding step that creates the first household and offers an invitation, and an invitation-acceptance route for the partner. Without this, household-based features (the whole product) have no entry point, and partners can't actually be invited in. **Email-based flows (magic link, invitations) are notoriously hard to test** — this proposal pins down a dev workflow that doesn't depend on real inboxes.
+
+## What Changes
+
+- **Landing page** (`/`):
+  - Public, no auth required.
+  - Headline: "Score boliger sammen. Bli enige raskere."
+  - Hero illustration (subtle, not loud).
+  - Primary CTA: `Registrer`. Secondary: `Logg inn`.
+  - Tone: rolig, ryddig, trygg (per design brief — Linear / Notion / Things 3 vibe, not corporate).
+- **Registrer** (`/registrer`) and **Logg inn** (`/logg-inn`):
+  - **Email + password** is the **primary, always-available** auth method (easiest to test, no email dependency).
+  - **Magic link** is offered as an alternative on both pages — labeled "Logg inn med e-postlenke i stedet".
+  - Minimal forms — no extra fields beyond what's required.
+- **Onboarding** (`/app/onboarding`) — runs immediately after first signup if user has zero households:
+  - Single field: "Hva skal vi kalle husholdningen deres?" (placeholder example: `Ine & Kanta` or `Vårt boligsøk`).
+  - On submit: create household, make user owner.
+  - Then show two CTAs:
+    - Primary: `Kopier invitasjonslenke`.
+    - Secondary: `Send via e-post` (opens email field, sends invitation email with token).
+  - Helper text: "Send denne lenken til din partner for å score boliger sammen."
+  - Skip option: `Hopp over — legg til senere`. Skip routes user to `/app` empty state.
+- **Invitation acceptance** (`/invitasjon/[token]`):
+  - If not logged in → redirect to register/login first, return to this URL after.
+  - Show: "Ine har invitert deg til husholdningen 'Ine & Kanta' som [rolle]. Godta?" with `Bli med` button.
+  - On accept: add user as member with the role specified in the invitation (default `member`), redirect to `/app`.
+  - Error states: token expired ("Denne lenken har utløpt. Be om en ny."), token already used, user already a member.
+- **Logg ut**: action lives **only on the `Meg` page** (not in header/nav). Clears Supabase session, redirects to `/`.
+
+## Email infrastructure
+
+- **Local dev**: use **Supabase CLI + Mailpit**. Supabase local stack ships with Mailpit (a fake SMTP server with a web UI at `localhost:54324`). All outbound email — magic links AND invitation emails — lands there as a captured message you click. **No real inbox needed for end-to-end testing.** Document this in the repo `README` so future-you and agents don't fight magic-link auth in tests.
+- **Production**:
+  - **Magic link & password reset**: Supabase Auth's built-in email (rate-limited but adequate for a small-scale product).
+  - **Invitation emails**: **Resend** (transactional service) — invitation deliverability matters more than auth emails (auth emails the user expects, invitation emails arrive cold to a partner). Configure via Supabase Edge Function or Next.js API route.
+- **Staging**: same as production but with a verified test domain.
+- **Test mode flag**: an env var `NEXT_PUBLIC_TEST_MODE_BYPASS=true` enables a `/dev/login` route that signs in a seeded test user with one click. Available only when env is set; surfaced via build guard so it can't ship to prod by accident. Used by e2e tests.
+
+## Capabilities
+
+### New Capabilities
+- `auth-onboarding`: landing page, registration/login (password + magic link), first-run household onboarding, invitation acceptance flow with role propagation, logout, dev-mode email capture via Mailpit.
+
+### Modified Capabilities
+<!-- None - replaces v1's bare auth screen entirely. -->
+
+## Out of MVP scope (future)
+
+- **OAuth providers** (Google, Apple): out of scope. Email/password + magic link is enough.
+- **2FA**: out of scope.
+- **Password reset UI**: Supabase's default "forgot password" email flow suffices in MVP. Custom UI later.
+
+## Impact
+
+- **Auth (Supabase)**: enable email/password + magic-link providers, configure email templates (Norwegian copy), set redirect URLs.
+- **Email delivery**: Mailpit in dev (Supabase CLI native), Resend in prod for invitation emails. Need a Resend API key in env vars.
+- **Database**: writes to `households` + `household_members` (from onboarding) and `household_invitations` (already defined in `households` capability).
+- **Routes added**: `/`, `/registrer`, `/logg-inn`, `/app/onboarding`, `/invitasjon/[token]`, plus dev-only `/dev/login` (gated by env var). Plus a route guard for `/app/*` that redirects unauthenticated users to `/logg-inn`.
+- **UI**: new public-facing landing page (different layout from app shell), minimal auth forms, onboarding screen with copy/share affordances.
+- **Repo docs**: `README` section "Local development email testing" explaining the Mailpit URL and how to run Supabase CLI locally.
+- **Dependencies**: requires `households` (for entity creation) and `navigation-shell` (for `/app/*` route protection and post-login destination). Blocks nothing else but is the entry point users hit first.

--- a/openspec/changes/auth-onboarding/specs/auth-onboarding/spec.md
+++ b/openspec/changes/auth-onboarding/specs/auth-onboarding/spec.md
@@ -1,0 +1,184 @@
+## ADDED Requirements
+
+### Requirement: Public landing page
+
+The system SHALL render a public landing page at `/` that requires no authentication. The page SHALL contain a headline, supporting text, a primary CTA labeled "Registrer", and a secondary CTA labeled "Logg inn".
+
+#### Scenario: Anonymous visit to landing
+
+- **WHEN** an unauthenticated user visits `/`
+- **THEN** the landing page renders without redirect
+- **AND** displays headline `Score boliger sammen. Bli enige raskere.`, primary CTA `Registrer`, secondary CTA `Logg inn`
+
+#### Scenario: Authenticated visit to landing
+
+- **WHEN** an authenticated user visits `/`
+- **THEN** the landing page still renders (it is not auto-redirecting), with the option for the user to continue to `/app` via a header link or by clicking either CTA
+
+### Requirement: Email/password registration
+
+The system SHALL allow new users to register with an email and password via Supabase Auth. After successful registration, the user SHALL be routed to the post-auth destination — `next` param if same-origin and present, otherwise `/app/onboarding`.
+
+#### Scenario: Successful registration
+
+- **WHEN** a new user submits valid email + password (≥ 8 chars) on `/registrer`
+- **THEN** Supabase creates an account
+- **AND** the user is signed in (in dev) or shown a "kontroller e-post" notice (in prod, awaiting confirmation)
+- **AND** in dev, the user is routed to `/app/onboarding`
+
+#### Scenario: Registration with invalid email
+
+- **WHEN** a user submits a malformed email
+- **THEN** an inline validation error displays and no Supabase request is made
+
+#### Scenario: Registration with weak password
+
+- **WHEN** a user submits a password shorter than 8 characters
+- **THEN** an inline validation error displays and no Supabase request is made
+
+#### Scenario: Email already registered
+
+- **WHEN** a user submits an email that already has an account
+- **THEN** Supabase returns an error and the form displays "En konto med denne e-posten finnes allerede. Logg inn i stedet."
+
+#### Scenario: Registration with `next` param
+
+- **WHEN** a user registers via `/registrer?next=/invitasjon/abc123`
+- **AND** the registration succeeds (and email confirmation is satisfied if in prod)
+- **THEN** the user is routed to `/invitasjon/abc123`
+
+### Requirement: Email/password login
+
+The system SHALL allow existing users to log in with email + password via Supabase Auth.
+
+#### Scenario: Successful login
+
+- **WHEN** a user submits valid credentials on `/logg-inn`
+- **THEN** Supabase creates a session
+- **AND** the user is routed to the `next` param destination (if same-origin) or `/app`
+
+#### Scenario: Wrong password
+
+- **WHEN** a user submits an email that exists but the wrong password
+- **THEN** the form displays "Feil e-post eller passord."
+
+#### Scenario: Unconfirmed email (prod only)
+
+- **WHEN** a user submits credentials but their email is not yet confirmed
+- **THEN** the form displays "Kontroller e-post — vi har sendt en bekreftelseslenke"
+- **AND** offers a "send på nytt" action
+
+### Requirement: Magic link authentication (alternate)
+
+The system SHALL offer magic-link login as an alternative on both `/registrer` and `/logg-inn`. The user enters their email; a one-time-link is sent via Supabase email; clicking it logs them in.
+
+#### Scenario: Magic link request
+
+- **WHEN** a user enters their email and submits the magic-link form
+- **THEN** Supabase sends a magic-link email
+- **AND** the page displays "Sjekk e-posten din for å logge inn."
+
+#### Scenario: Magic link in dev
+
+- **WHEN** a magic link is sent in dev
+- **THEN** the email is captured by Mailpit at `http://localhost:54324`
+- **AND** clicking the link in Mailpit signs the user in and routes them per the `next` param or to `/app`
+
+### Requirement: First-run onboarding
+
+After registration (or first login if no household exists), the system SHALL route the user to `/app/onboarding`. The onboarding page SHALL ask for a household name and create the household on submit. After creation, the user SHALL be offered a copyable invitation link, with a `Hopp over` option.
+
+#### Scenario: First-run onboarding redirect
+
+- **WHEN** an authenticated user with zero households visits any `/app/*` route
+- **THEN** they are redirected to `/app/onboarding`
+
+#### Scenario: Create household
+
+- **WHEN** the user submits a household name on `/app/onboarding`
+- **THEN** a household is created (per `households` capability) and the user is its owner
+- **AND** the page advances to the invitation-link step
+
+#### Scenario: Skip invitation
+
+- **WHEN** the user clicks `Hopp over — legg til senere` on the invitation step
+- **THEN** they are routed to `/app` (with empty property list)
+
+#### Scenario: Copy invitation link
+
+- **WHEN** the user clicks `Kopier invitasjonslenke`
+- **THEN** the invitation URL is written to the clipboard
+- **AND** a confirmation toast displays "Lenke kopiert"
+
+#### Scenario: Onboarding only runs once
+
+- **WHEN** an authenticated user already in at least one household visits `/app/onboarding`
+- **THEN** they are redirected to `/app` (they can create more households via the switcher's "Opprett ny husholdning" entry)
+
+### Requirement: Invitation acceptance entry point for unauthenticated users
+
+The system SHALL allow `/invitasjon/[token]` to be visited by unauthenticated users. When unauthenticated, the system SHALL redirect to `/registrer?next=/invitasjon/[token]` (or to `/logg-inn?next=...` if the user clicks the login link).
+
+#### Scenario: Unauthenticated invitation visit
+
+- **WHEN** an unauthenticated user visits `/invitasjon/abc123`
+- **THEN** they are redirected to `/registrer?next=%2Finvitasjon%2Fabc123`
+
+#### Scenario: Authenticated invitation visit
+
+- **WHEN** an authenticated user visits `/invitasjon/abc123`
+- **THEN** the invitation acceptance UI renders (delegated to `households` capability)
+
+### Requirement: Logout
+
+The system SHALL expose a logout action only on `/app/meg`. Logout SHALL terminate the Supabase session and redirect to `/`.
+
+#### Scenario: Logout from Meg
+
+- **WHEN** an authenticated user clicks "Logg ut" on `/app/meg`
+- **THEN** the Supabase session is terminated
+- **AND** the user is redirected to `/`
+- **AND** subsequent visits to `/app/*` redirect them to `/logg-inn`
+
+#### Scenario: No logout in header or nav
+
+- **WHEN** a user inspects the header, household switcher, or bottom nav
+- **THEN** no logout action is present anywhere except on `/app/meg`
+
+### Requirement: Dev test bypass route
+
+The system SHALL provide `/dev/login` only when `NEXT_PUBLIC_DEV_LOGIN_ENABLED === '1'`. The route SHALL sign in a seeded test user (`alice@test.local` or `bob@test.local`, password `test1234`) selected via a query param `?as=alice|bob` and redirect to `/app`.
+
+#### Scenario: Dev login enabled
+
+- **WHEN** `NEXT_PUBLIC_DEV_LOGIN_ENABLED=1` and a request is made to `/dev/login?as=alice`
+- **THEN** the user is signed in as `alice@test.local` and redirected to `/app`
+
+#### Scenario: Dev login disabled (prod build)
+
+- **WHEN** the production build is deployed (no `NEXT_PUBLIC_DEV_LOGIN_ENABLED` or set to `0`)
+- **THEN** any request to `/dev/login` returns 404
+
+#### Scenario: Build-time prod guard
+
+- **WHEN** `NEXT_PUBLIC_DEV_LOGIN_ENABLED=1` is set during a prod build (`VERCEL_ENV=production`)
+- **THEN** the build fails with an error preventing deploy
+
+### Requirement: Open-redirect protection on `next` param
+
+The system SHALL validate that the `next` query parameter is a same-origin path before redirecting to it. Off-origin or absolute external URLs SHALL be ignored, and the user SHALL be sent to `/app` instead.
+
+#### Scenario: Same-origin `next` accepted
+
+- **WHEN** a user logs in via `/logg-inn?next=%2Fapp%2Fvekter`
+- **THEN** they are redirected to `/app/vekter`
+
+#### Scenario: External `next` rejected
+
+- **WHEN** a user logs in via `/logg-inn?next=https%3A%2F%2Fevil.com%2Fphish`
+- **THEN** the external URL is ignored and the user is redirected to `/app`
+
+#### Scenario: Malformed `next` rejected
+
+- **WHEN** the `next` param is not a valid URL or path
+- **THEN** the param is ignored and the user is redirected to `/app`

--- a/openspec/changes/auth-onboarding/tasks.md
+++ b/openspec/changes/auth-onboarding/tasks.md
@@ -1,0 +1,81 @@
+> Conventions: see `openspec/conventions.md`.
+
+## 1. Supabase auth configuration
+
+- [ ] 1.1 In Supabase project dashboard (or `supabase/config.toml` for local): enable email/password and magic link providers; set Site URL to deploy origin.
+- [ ] 1.2 Set redirect URLs whitelist: `http://localhost:3000/**`, `https://*.vercel.app/**`, prod domain.
+- [ ] 1.3 In dev (`supabase/config.toml`): `[auth.email] enable_confirmations = false`. In prod (Supabase dashboard): `enable_confirmations = true`.
+- [ ] 1.4 Customize email templates (Norwegian copy) for: magic link, signup confirmation, password reset.
+- [ ] 1.5 Verify Mailpit captures emails: run `supabase start`, trigger a password reset, see it in Mailpit at `http://localhost:54324`.
+
+## 2. Public landing page
+
+- [ ] 2.1 `app/page.tsx` — headline "Score boliger sammen. Bli enige raskere.", supporting text, primary CTA `Registrer` (link to `/registrer`), secondary CTA `Logg inn` (link to `/logg-inn`).
+- [ ] 2.2 Subtle hero illustration or screenshot; no marketing scroll, no testimonials.
+- [ ] 2.3 Norwegian copy throughout. Tone: rolig, ryddig, trygg.
+
+## 3. Register page
+
+- [ ] 3.1 `app/registrer/page.tsx` — form with email + password fields. "Logg inn med e-postlenke i stedet" link reveals the magic-link form variant.
+- [ ] 3.2 Server action `registerWithPassword({ email, password, next })` calls Supabase signup. Handles errors: invalid email, weak password, already registered.
+- [ ] 3.3 Server action `requestMagicLink({ email, next })` calls `signInWithOtp` with `emailRedirectTo`.
+- [ ] 3.4 Validate `next` param is same-origin; default to `/app/onboarding`.
+- [ ] 3.5 Inline validation errors in Norwegian.
+
+## 4. Login page
+
+- [ ] 4.1 `app/logg-inn/page.tsx` — same structure as register; email + password and magic-link variant.
+- [ ] 4.2 Server action `loginWithPassword({ email, password, next })`. Handle errors: wrong password, unconfirmed email (prod), generic.
+- [ ] 4.3 Default `next` is `/app`.
+- [ ] 4.4 Forgot-password link routes to Supabase's default reset flow.
+
+## 5. Onboarding page
+
+- [ ] 5.1 `app/app/onboarding/page.tsx` — single-input form: "Hva skal vi kalle husholdningen deres?". On submit, calls `createHousehold` (from `households` capability).
+- [ ] 5.2 After creation, advance to invitation step: invitation link generated immediately, "Kopier invitasjonslenke" button copies it. Helper text per the brief.
+- [ ] 5.3 "Hopp over — legg til senere" button routes to `/app`.
+- [ ] 5.4 Auto-redirect logic: in `app/app/layout.tsx`, if authenticated user has zero households AND not currently on `/app/onboarding`, redirect to `/app/onboarding`.
+- [ ] 5.5 Reverse guard: if user already has at least one household and visits `/app/onboarding` directly, redirect to `/app`.
+
+## 6. Logout action
+
+- [ ] 6.1 `app/app/meg/page.tsx` — placeholder Meg page (will be expanded later) with "Logg ut" button.
+- [ ] 6.2 Server action `signOut()` calls `supabase.auth.signOut()` and redirects to `/`.
+- [ ] 6.3 Verify no logout action appears in the header or bottom nav (audit `<AppShellHeader>` and `<BottomNav>` from `navigation-shell`).
+
+## 7. Dev login bypass
+
+- [ ] 7.1 `app/dev/login/route.ts` — route handler. Reads `as` query param (`alice` or `bob`), signs in via `signInWithPassword`, redirects to `/app`.
+- [ ] 7.2 Wrap entire handler in `if (process.env.NEXT_PUBLIC_DEV_LOGIN_ENABLED !== '1') return new Response(null, { status: 404 })`.
+- [ ] 7.3 Build-time guard in `next.config.mjs`: `if (process.env.VERCEL_ENV === 'production' && process.env.NEXT_PUBLIC_DEV_LOGIN_ENABLED === '1') throw new Error('dev/login MUST be disabled in production')`.
+- [ ] 7.4 Test users seeded via `supabase/seed.sql`: `alice@test.local` and `bob@test.local`, password `test1234` (per conventions.md).
+
+## 8. Invitation acceptance handoff
+
+This page lives in `households` capability (`app/invitasjon/[token]/page.tsx`); this capability only contributes the **redirect-when-unauthenticated** behavior, which lives in middleware or in the page itself.
+
+- [ ] 8.1 In `app/invitasjon/[token]/page.tsx` (created by `households`): if unauthenticated, redirect to `/registrer?next=/invitasjon/<token>`. (Document the requirement here; implementation may be split.)
+- [ ] 8.2 Verify `next` param round-trip works for both `/registrer` and `/logg-inn` paths.
+
+## 9. Open-redirect protection
+
+- [ ] 9.1 Helper `validateNext(next: string | undefined): string` — returns `next` if it's a relative path starting with `/` and not starting with `//`, else returns `/app`.
+- [ ] 9.2 Use this helper in every redirect-after-auth path: register, login, magic link, dev login.
+- [ ] 9.3 Unit test the helper for: relative path → returns it; absolute URL → returns `/app`; protocol-relative `//evil.com` → returns `/app`; undefined → returns `/app`; non-string → returns `/app`.
+
+## 10. Tests
+
+- [ ] 10.1 **Unit (Vitest)**: `validateNext` helper covers all cases above.
+- [ ] 10.2 **E2E (Playwright)**: full funnel — landing → register → onboarding (create household) → see empty `/app`. With email/password (no email needed in dev).
+- [ ] 10.3 **E2E**: invitation flow end-to-end — Alice creates a household via dev-login; copies invitation link; Bob (new browser context) opens link, gets redirected to register, signs up, accepts invitation, lands on `/app` with the new household active.
+- [ ] 10.4 **E2E**: magic link via Mailpit — request a magic link, poll Mailpit's HTTP API for the captured message, follow the link, verify session.
+- [ ] 10.5 **E2E**: logout — sign in, click "Logg ut" in `Meg`, assert redirected to `/` and `/app/*` redirects to `/logg-inn`.
+- [ ] 10.6 **E2E**: open-redirect attack — `/logg-inn?next=https://evil.com` redirects to `/app` after login, NOT to evil.com.
+- [ ] 10.7 **E2E**: `/dev/login` returns 404 in production build (asserted via `NEXT_PUBLIC_DEV_LOGIN_ENABLED` unset).
+- [ ] 10.8 **E2E**: onboarding auto-redirect — newly registered user lands on `/app/onboarding`; visiting `/app/vekter` directly redirects them to `/app/onboarding`.
+
+## 11. Documentation
+
+- [ ] 11.1 Update root `README.md`: section "Authentication & local testing" explaining email/password vs magic link, where Mailpit is, how to use `/dev/login`.
+- [ ] 11.2 `docs/architecture/auth.md` — short doc describing the auth flow, route protection, and dev bypass.
+- [ ] 11.3 `.env.example` — document `NEXT_PUBLIC_DEV_LOGIN_ENABLED`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`.

--- a/openspec/changes/comparison/.openspec.yaml
+++ b/openspec/changes/comparison/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/comparison/README.md
+++ b/openspec/changes/comparison/README.md
@@ -1,0 +1,3 @@
+# comparison
+
+Side-by-side scoring matrix with felles-score and disagreement highlighting

--- a/openspec/changes/comparison/design.md
+++ b/openspec/changes/comparison/design.md
@@ -1,0 +1,109 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Context
+
+Comparison is the **payoff** of the product — independent partner scoring is only valuable if you can see disagreement and reconcile. The brief calls for a matrix view (rows = criteria, columns = `Ine | Kanta | Snitt | Felles`), inline-editable felles column, disagreement highlighting (`|Δ| ≥ threshold`), and a hero totalscore panel showing `Felles: 78/100` with smaller `Din: 76` / `Kanta: 82` underneath. This capability turns the raw score tables from `scoring` and the weight tables from `weights` into the headline numbers used everywhere else (sorted list cards, totalscore panel, etc.).
+
+## Goals / Non-Goals
+
+**Goals:**
+- `Sammenligning` tab at `/app/bolig/[id]/sammenligning`.
+- Totalscore-panel: `Felles: 78`, `Din: 76`, `Kanta: 82`, with warning when criteria are missing felles scores.
+- Matrix grouped by section: `Kriterium | Ine | Kanta | Snitt | Felles`. Inline-editable Felles column via chip-picker.
+- Disagreement highlighting on rows where `|Ine_score − Kanta_score| ≥ household.comparison_disagreement_threshold` (default 3, configurable).
+- Felles-score storage: `property_felles_scores(property_id, criterion_id, score, updated_by, updated_at)`.
+- Single-user fallback: tab still renders; `Kanta`/`Snitt` columns hidden; `Felles` simplifies to the user's score.
+- Polling-on-focus refresh (no realtime in MVP).
+
+**Non-Goals:**
+- **Realtime sync** via Supabase Realtime — deferred to a follow-up change. MVP refetches on tab focus and after each local edit.
+- **History of felles-score changes** — could be added later via trigger. Out of MVP.
+- **Suggestion engine / "you usually agree on X"** — out of scope.
+- **Per-criterion comments thread** — different feature; out of scope.
+- **Partner activity indicators** ("Kanta is currently scoring this") — premature optimization.
+
+## Decisions
+
+### D1. Felles scores stored, not derived
+
+**Choice**: `property_felles_scores(property_id, criterion_id, score, updated_by, updated_at)`. One row per scored criterion (sparse — rows exist only after the felles score is set).
+
+**Alternative considered**: derive felles_score = average of partner scores, no storage.
+
+**Rationale**: brief explicitly says felles is editable independently of partner averages — the household can override the average ("we'll go with 8 even though you scored 7 and I scored 6"). Storage is the only way to capture that override. Default value (when row absent) is the average, computed at read time.
+
+### D2. Felles is sparse — absent row means "not set"
+
+**Choice**: a missing `property_felles_scores` row means felles is unset for that criterion. UI fills it with the partner average as a default value, but until the user actively confirms (taps), no row is written. Once written, the felles is treated as authoritative.
+
+**Alternative considered**: insert all 22 rows on first comparison-tab load with the average as the value.
+
+**Rationale**: a sparse table is honest about which felles scores have been actively agreed on. The brief shows a warning "X kriterier mangler score — regnes som 0 i totalen" — this is the count of rows missing a felles score. With sparse storage, that count is `22 - count(rows)`.
+
+### D3. Default felles = average of partner scores; tap to commit
+
+**Choice**: when the comparison matrix renders, the `Felles` column shows `Snitt` as a placeholder for unset felles. Tapping the cell opens a chip-picker; selecting writes the row.
+
+**Rationale**: removes friction — most felles scores will be the average, so don't make the user retype it. But also doesn't auto-fill the database, preserving the "intentionally not yet agreed on" semantics.
+
+### D4. Threshold lives on `households` table
+
+**Choice**: `households.comparison_disagreement_threshold INT NOT NULL DEFAULT 3 CHECK (BETWEEN 1 AND 10)`. Already added in `households` schema (D11 there).
+
+**Rationale**: per-household setting (not per-user, not per-property). Surfaced in `Husstand` settings UI.
+
+### D5. Single-user household renders the tab with collapsed UI
+
+**Choice**: when there's only one member, the matrix shows three columns: `Kriterium | Din | Felles`. The `Felles` column simplifies to "din score blir felles" (with the option to override). Totalscore panel shows only `Din total`.
+
+**Rationale**: the tab is still useful — the single user sees their own scores in matrix form and can adjust the felles. Hides partner-comparison machinery cleanly. When a partner joins later, the tab "lights up" without restructuring.
+
+### D6. Polling-on-focus refresh, not Supabase Realtime
+
+**Choice**: refetch the tab data when (a) the tab regains focus (`visibilitychange` event) and (b) after each local edit (autosave). No subscription.
+
+**Rationale**: MVP keeps things simple. Realtime adds connection management, fallback handling for connection loss, and per-table channel limits in Supabase free tier. The feature works fine with focus-refresh — the worst case is a 30-second delay before seeing partner edits, which is acceptable for a "we score together at viewings" use-case.
+
+### D7. Math contract
+
+**Choice**: total formulas:
+- `felles_total = round(Σ (felles_score[c] × household_weight[c]) / Σ (household_weight[c]) × 10)` — sum only over criteria with a felles_score set; missing felles counts as `0` in numerator.
+- `din_total = round(Σ (your_score[c] × your_user_weight[c]) / Σ (your_user_weight[c]) × 10)` — sum only over criteria you've scored.
+- `partner_total` = same formula with partner's data.
+- Output range: 0–100 (integer).
+- Divide-by-zero (all weights 0): display "Ikke nok data".
+
+**Rationale**: matches the brief's example "Felles: 78/100". Weighted average rescaled to 0–100 is intuitive. Missing felles → 0 is the punishment for incompleteness, surfaced via the warning text.
+
+### D8. Inline-edit chip-picker (not full chip-rad)
+
+**Choice**: tapping a Felles cell opens a small popover containing the 11 chips (0–10) in two rows of 6. Tap to select, autosave, popover closes.
+
+**Alternative considered**: render the full 11-chip rad inline in every row.
+
+**Rationale**: inline 11-chip rads in 22 rows × 1 column = 22 rad widgets stacked. On mobile, that's narrow chips and an aesthetically chaotic matrix. A popover keeps the matrix dense and readable; the popover is touch-friendly with its own large chips.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Sparse `property_felles_scores` confusing for the partial-state UI | Spec scenario explicitly tests "X kriterier mangler score" warning. Helper function returns the count of unset felles rows. |
+| Two members editing the same felles cell at the same time | Last-write-wins. `updated_by` and `updated_at` recorded. UI refresh-on-focus surfaces the partner's edit. Acceptable; brief explicitly says "den som sist redigerte 'felles' er den som står". |
+| Matrix performance with many properties × refetches | Each comparison view fetches one property's data — small (~22 rows × 4 columns). No issue. |
+| `partner_total` requires fetching partner's scores — leak risk | Server-side query fetches partner scores ONLY when the calling user is a member of the same household AND there is exactly one partner (`household_members.count = 2`). For 3+ member households, "partner" is undefined; render aggregate "Andre medlemmer" or punt: MVP assumes 1–2 members per household. |
+| Threshold change retroactively re-highlights | Acceptable — that's the point. Threshold is a display-only setting; no migration on change. |
+| Felles totalscore mismatches the matrix's row-by-row math due to rounding | Use integer math at the end (multiply, sum, divide, multiply by 10, round). Avoid floats in the sum. Document the formula in `docs/architecture/comparison.md`. |
+
+## Resolved Decisions
+
+### D9. 3+ member households — out of scope for MVP
+
+**Choice**: brief and product framing assume 1–2 members. If a household has 3+ members, the comparison tab shows the felles total + the current user's `Din total` only. No "partner" column, no comparison matrix beyond `Kriterium | Din | Felles`.
+
+**Rationale**: most households are couples. Don't over-engineer for the family-of-four case. We can add multi-member rendering later if it materializes.
+
+### D10. Round to integer at the end
+
+**Choice**: `round(... × 10)` produces a 0–100 integer. Display as "78", not "78.4".
+
+**Rationale**: brief says "Felles: 78/100". Whole numbers are easier to compare and feel more authoritative.

--- a/openspec/changes/comparison/proposal.md
+++ b/openspec/changes/comparison/proposal.md
@@ -1,0 +1,51 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Why
+
+Independent scoring is only valuable if the partners can **see disagreement and reconcile**. Without comparison, the two sets of numbers sit in isolated tabs and the household still can't rationally rank Bolig A vs Bolig B. The comparison view turns the raw scores into a structured conversation: "we differ by 3 on kjøkken — let's talk." It also produces the **Felles totalscore** (the headline number) used everywhere else (sorting, list cards, decision-making).
+
+## What Changes
+
+- New `Sammenligning` tab on the property detail page. Visible if at least the current user has scored.
+- **Totalscore-panel** at the top:
+  - Hero: `Felles: 78/100` (large) — based on felles-karakter × felles-vekter.
+  - Secondary: `Din: 76` and `Kanta: 82` (smaller).
+  - Warning if any criterion is missing a felles score: `⚠ 3 kriterier mangler score — regnes som 0 i totalen`.
+- **Comparison matrix** (rows grouped by section, same sections as scoring):
+  - Columns: `Kriterium | Ine | Kanta | Snitt | Felles`.
+  - `Felles` column is **inline-editable** — tap the number, chip-picker opens, autosave on select.
+  - `Felles` is prefilled with `Snitt` as the default, but either partner can override.
+  - Rows where `|Δ| ≥ threshold` (default 3) get a subtle highlight (e.g. soft yellow background).
+- **Disagreement threshold is configurable** per household. Setting lives on the `households` row (`comparison_disagreement_threshold`, default `3`, range 1–10). Surfaced in `Husstand` settings (or `Meg`/`Innstillinger`).
+- No explicit "commit" button — last edit wins.
+- **No real-time push** in MVP. The matrix re-fetches on **tab focus** and after any local edit (refetch after autosave). Real-time subscription via Supabase Realtime is a later upgrade.
+- Empty/partial states:
+  - **Single-user household** (no partner yet): tab renders, but `Kanta` and `Snitt` columns are hidden. `Felles` column simplifies to "din score blir felles". Totalscore-panel shows only `Din total` (felles defaults to your scores × felles weights when no partner).
+  - Partner is in household but has not scored: show only your scores in the `Din` column, label `Snitt` and `Felles` as `— venter på partner`.
+- Felles total recalculates after each edit (client-side, since polling drives the data).
+
+## Capabilities
+
+### New Capabilities
+- `comparison`: matrix view, felles-karakter editing, felles-totalscore calculation, configurable disagreement threshold, partial-state handling (single-user, partner-not-scored).
+
+### Modified Capabilities
+<!-- None - new tab, doesn't change scoring or weights specs. -->
+
+## Out of MVP scope (future)
+
+- **Real-time partner sync**: Supabase Realtime subscription so the matrix updates live as your partner scores. MVP uses fetch-on-focus + refetch-after-edit.
+
+## Impact
+
+- **Database**:
+  - `property_felles_scores(property_id, criterion_id, score, updated_by, updated_at)` — one row per (property × criterion) representing the household's agreed-upon score. Either member can write (viewers cannot).
+  - `households.comparison_disagreement_threshold INT NOT NULL DEFAULT 3 CHECK (BETWEEN 1 AND 10)`.
+- **Math**:
+  - `felles_total = round(Σ (felles_score[c] × felles_weight[c]) / Σ (felles_weight[c]) × 10)`. Missing felles score counts as 0 in numerator (warning shown).
+  - `din_total = round(Σ (your_score[c] × your_personal_weight[c]) / Σ (your_personal_weight[c]) × 10)`.
+  - `partner_total` same with partner's data.
+  - All totals are derived (computed client-side or as a SQL view), never stored.
+- **UI**: new matrix component, chip-picker popover, disagreement-highlight styling, totalscore badge component, threshold setting in Husstand or Meg.
+- **Routes**: `/app/bolig/[id]/sammenligning`.
+- **Dependencies**: requires `households`, `properties`, `scoring`, `weights`.

--- a/openspec/changes/comparison/specs/comparison/spec.md
+++ b/openspec/changes/comparison/specs/comparison/spec.md
@@ -1,0 +1,193 @@
+## ADDED Requirements
+
+### Requirement: Felles score storage
+
+The system SHALL store felles scores in `property_felles_scores(property_id, criterion_id, score, updated_by, updated_at)` with `score INT CHECK (score BETWEEN 0 AND 10)`. The composite `(property_id, criterion_id)` SHALL be the primary key. Rows are sparse — absence means "felles not set for this criterion".
+
+#### Scenario: Member sets a felles score
+
+- **WHEN** a member sets the felles score for a property × criterion to 8
+- **THEN** a row is upserted with `score = 8`, `updated_by = caller`, `updated_at = now()`
+
+#### Scenario: Viewer cannot set felles
+
+- **WHEN** a `viewer` attempts to upsert a felles score
+- **THEN** RLS denies the operation
+
+#### Scenario: Sparse storage
+
+- **WHEN** a property has felles scores set for 18 of 22 criteria
+- **THEN** `property_felles_scores` has exactly 18 rows for that property; the 4 unset criteria have no rows
+
+#### Scenario: Out of range rejected
+
+- **WHEN** a user attempts to set `score = 11`
+- **THEN** the database CHECK constraint rejects the operation
+
+### Requirement: Sammenligning tab — totalscore panel
+
+The system SHALL render at the top of `/app/bolig/[id]/sammenligning` a totalscore panel containing: a hero `Felles: <N>/100`, smaller `Din: <N>` and `<Partner>: <N>` numbers, and a warning row when one or more criteria are missing a felles score.
+
+#### Scenario: Two-member household, fully scored
+
+- **WHEN** a property in a two-member household has felles scores for all 22 criteria
+- **THEN** the panel renders `Felles: 78` (or whatever the math produces), `Din: <N>`, `<Partner>: <N>`
+- **AND** no warning row appears
+
+#### Scenario: Missing felles scores
+
+- **WHEN** 3 of 22 criteria lack a felles score
+- **THEN** the panel shows the warning "⚠ 3 kriterier mangler score — regnes som 0 i totalen"
+
+#### Scenario: All-zero weights graceful display
+
+- **WHEN** the household_weights all equal 0 (denominator zero)
+- **THEN** `Felles` shows "Ikke nok data" instead of a number
+- **AND** the warning row is suppressed (it's redundant with the broader issue)
+
+#### Scenario: Single-member household totalscore panel
+
+- **WHEN** a property is in a single-member household
+- **THEN** the panel shows only `Din: <N>`; `Felles` and `<Partner>` are hidden
+
+### Requirement: Sammenligning tab — comparison matrix (two-member case)
+
+The system SHALL render a matrix grouped by criterion section with columns `Kriterium | Ine | Kanta | Snitt | Felles` (the partner names are filled in dynamically). The `Felles` column SHALL be inline-editable for `owner` and `member`, read-only for `viewer`.
+
+#### Scenario: Matrix renders all 22 criteria grouped by section
+
+- **WHEN** an owner/member opens the tab in a two-member household
+- **THEN** all 22 rows render under their three section headers
+
+#### Scenario: Cell content for fully-scored row
+
+- **WHEN** both members have scored a criterion (8 and 6)
+- **THEN** the row shows `Ine: 8`, `Kanta: 6`, `Snitt: 7`, and the Felles cell shows the felles score (or `7` as the placeholder snitt if no felles set)
+
+#### Scenario: Cell content for partially-scored row
+
+- **WHEN** the current user has scored a criterion (7) but the partner has not
+- **THEN** the row shows `Ine: 7`, `Kanta: —`, `Snitt: —`, `Felles: —`
+
+#### Scenario: Cell content for unscored row
+
+- **WHEN** neither member has scored a criterion
+- **THEN** the row renders all values as `—`
+
+#### Scenario: Disagreement highlight
+
+- **WHEN** a row has `|Ine_score − Kanta_score| ≥ household.comparison_disagreement_threshold` (default 3)
+- **THEN** the row is rendered with a subtle highlight (background color or left border)
+
+#### Scenario: Threshold change re-renders highlights
+
+- **WHEN** the household owner changes `comparison_disagreement_threshold` from 3 to 2
+- **THEN** the matrix re-renders with rows where `|Δ| ≥ 2` highlighted (after refetch on next render)
+
+### Requirement: Inline edit of Felles column
+
+The system SHALL allow `owner` and `member` to set the felles score by tapping a Felles cell, which opens a chip-picker popover with chips 0–10. Selecting a chip SHALL upsert the felles row and close the popover.
+
+#### Scenario: Open chip-picker
+
+- **WHEN** an owner/member taps a Felles cell
+- **THEN** a popover opens displaying chips 0–10
+- **AND** the currently set value (or snitt placeholder) is highlighted
+
+#### Scenario: Select chip saves immediately
+
+- **WHEN** the user selects chip `8` in the popover
+- **THEN** the felles score is upserted to 8
+- **AND** the popover closes
+- **AND** the totalscore panel recalculates
+
+#### Scenario: Tap outside dismisses without save
+
+- **WHEN** the user opens a chip-picker but taps outside before selecting
+- **THEN** the popover closes; no upsert occurs
+
+#### Scenario: Viewer cannot open chip-picker
+
+- **WHEN** a viewer taps a Felles cell
+- **THEN** the cell does not open the picker (or opens read-only)
+- **AND** the row remains unchanged
+
+### Requirement: Single-member household variant
+
+The system SHALL render a simplified two-column matrix (`Kriterium | Din | Felles`) when the active household has exactly one member. The `Felles` column SHALL prefill with `Din` as the placeholder; the user can override.
+
+#### Scenario: Single-member matrix
+
+- **WHEN** an owner/member opens the tab in a single-member household
+- **THEN** the matrix shows columns `Kriterium | Din | Felles` (no `Snitt`, no partner)
+- **AND** rows display the user's score in `Din`, the felles score (or `Din` value as placeholder) in `Felles`
+
+#### Scenario: Felles editable in single-member case
+
+- **WHEN** a single-member user taps a Felles cell
+- **THEN** the chip-picker opens; selection upserts as normal
+
+### Requirement: 3+ member household variant
+
+When a household has more than two members, the system SHALL render a simplified `Kriterium | Din | Felles` matrix and the totalscore panel SHALL show only `Felles` and `Din` (no per-partner numbers). The full multi-member comparison matrix is out of MVP scope.
+
+#### Scenario: Three-member household renders simplified matrix
+
+- **WHEN** a household with 3+ members views the comparison tab
+- **THEN** the matrix shows only `Kriterium | Din | Felles`
+- **AND** the totalscore panel shows `Felles: <N>` and `Din: <N>` only
+
+### Requirement: Refresh on tab focus
+
+The system SHALL refetch the comparison data when the browser tab regains focus (`visibilitychange` event with `document.visibilityState === 'visible'`) and after every local felles-score edit.
+
+#### Scenario: Tab focus triggers refetch
+
+- **WHEN** the tab is hidden and then becomes visible again
+- **THEN** the comparison data is refetched
+- **AND** any partner-side changes that occurred while hidden are reflected
+
+#### Scenario: Edit triggers refetch
+
+- **WHEN** the user upserts a felles score
+- **THEN** the totalscore panel and matrix re-render with the latest data
+
+### Requirement: Threshold configuration
+
+The system SHALL allow `owner` to change `households.comparison_disagreement_threshold` to any integer in `[1, 10]`. The setting SHALL be surfaced in `Husstand` (or `Meg` → `Innstillinger`) UI.
+
+#### Scenario: Owner changes threshold
+
+- **WHEN** an `owner` updates the threshold from 3 to 2
+- **THEN** the value is persisted to `households.comparison_disagreement_threshold`
+
+#### Scenario: Member cannot change threshold
+
+- **WHEN** a `member` or `viewer` attempts to change the threshold
+- **THEN** RLS denies the update
+
+#### Scenario: Out of range rejected
+
+- **WHEN** a user attempts to set the threshold to 0 or 11
+- **THEN** the CHECK constraint rejects the value
+
+### Requirement: Felles totalscore math
+
+The system SHALL compute `felles_total = round((Σ over c with felles set: felles_score[c] × household_weight[c]) / (Σ over all c: household_weight[c]) × 10)`. Criteria without a felles score are NOT skipped — they contribute `0` to the numerator, but the denominator still uses ALL household weights so missing felles scores reduce the total.
+
+#### Scenario: Fully-scored felles total
+
+- **WHEN** all 22 felles scores are set
+- **THEN** `felles_total` is the standard weighted average × 10, rounded to integer
+
+#### Scenario: Partially-scored penalizes total
+
+- **WHEN** 18 of 22 felles scores are set
+- **THEN** the unset 4 contribute `0` to the numerator
+- **AND** the denominator uses all 22 weights
+- **AND** the resulting total is lower than if those 4 had been filled in
+
+#### Scenario: All weights zero
+
+- **WHEN** every household_weight = 0
+- **THEN** `felles_total` is reported as null and UI displays "Ikke nok data"

--- a/openspec/changes/comparison/tasks.md
+++ b/openspec/changes/comparison/tasks.md
@@ -1,0 +1,67 @@
+> Conventions: see `openspec/conventions.md`.
+
+## 1. Database schema
+
+- [ ] 1.1 Migration: create `property_felles_scores(property_id uuid REFERENCES properties(id) ON DELETE CASCADE, criterion_id uuid REFERENCES criteria(id) ON DELETE RESTRICT, score int NOT NULL CHECK (score BETWEEN 0 AND 10), updated_by uuid NOT NULL REFERENCES auth.users(id), updated_at timestamptz NOT NULL default now(), PRIMARY KEY (property_id, criterion_id))`. Index on `property_id`.
+- [ ] 1.2 `households.comparison_disagreement_threshold` already added by `households` capability (per its tasks 2.2). Verify default `3` and CHECK `BETWEEN 1 AND 10`.
+
+## 2. RLS policies
+
+- [ ] 2.1 Enable RLS on `property_felles_scores`.
+- [ ] 2.2 SELECT: caller is a member of the property's household (JOIN through `properties`).
+- [ ] 2.3 INSERT/UPDATE/DELETE: `has_household_role(<property's household_id>, ARRAY['owner','member'])` — viewer denied. `updated_by` MUST equal `auth.uid()` (enforced via DEFAULT auth.uid() and trigger that rejects mismatched values).
+
+## 3. SQL math functions
+
+- [ ] 3.1 Function `compute_felles_total(p_property_id uuid)` returns int|null. Numerator: `Σ (felles_score × household_weight)` over criteria with felles set. Denominator: `Σ household_weight` over ALL criteria. Returns `round((num/den) × 10)::int`. Returns NULL if denominator is 0.
+- [ ] 3.2 Function `compute_user_total(p_property_id uuid, p_user_id uuid)` similar but uses `property_scores` × `user_weights`.
+- [ ] 3.3 Function `get_property_comparison(p_property_id uuid, p_viewer_id uuid)` returns a row containing: property fields, threshold, member count, an array of `{criterion_id, section_id, criterion_label, your_score, partner_score, partner_user_id, snitt, felles_score}`, and the three totalscores.
+- [ ] 3.4 Test that the math matches a hand-computed example.
+
+## 4. Server actions / data layer
+
+- [ ] 4.1 `setFellesScore(propertyId, criterionId, score)` — upsert. Returns the new `felles_total` for client to update without full refetch.
+- [ ] 4.2 `clearFellesScore(propertyId, criterionId)` — DELETE.
+- [ ] 4.3 `getComparison(propertyId)` — wraps `get_property_comparison` SQL function.
+- [ ] 4.4 `setDisagreementThreshold(householdId, threshold)` — owner only.
+
+## 5. UI — Sammenligning tab
+
+- [ ] 5.1 `app/app/bolig/[id]/sammenligning/page.tsx` — server-fetches `getComparison`; passes data + viewer's role to a client component.
+- [ ] 5.2 `<TotalscorePanel>` — renders `Felles` (hero), `Din`, `<Partner>` (small). Warning bar for missing felles count. Empty state for single-member.
+- [ ] 5.3 `<ComparisonMatrix>` — three section blocks; each block renders `<MatrixRow>` per criterion.
+- [ ] 5.4 `<MatrixRow>` — columns `Kriterium | Ine | Kanta | Snitt | Felles`. Highlights row when `|Δ| ≥ threshold`. `Felles` cell is interactive.
+- [ ] 5.5 `<FellesCell>` — clickable; opens `<ChipPickerPopover>`. Shows current felles or snitt placeholder. Disabled for viewer.
+- [ ] 5.6 `<ChipPickerPopover>` — 11 chips arranged 6+5. Selection calls `setFellesScore` then closes. Backdrop tap dismisses without save.
+- [ ] 5.7 Single-member fallback: if `member_count === 1`, render the simplified 2-column matrix and the simplified totalscore panel.
+- [ ] 5.8 3+ member fallback: same simplified UI as single-member case.
+
+## 6. Refresh on focus
+
+- [ ] 6.1 Custom hook `useFocusRefresh(callback, debounceMs = 200)` listens for `visibilitychange` and `focus` events; calls `callback` when the tab becomes visible.
+- [ ] 6.2 Mount the hook in the comparison page client component to refetch `getComparison` on focus.
+- [ ] 6.3 Also refetch after every successful `setFellesScore` (server action returns the new total; client merges).
+
+## 7. Threshold setting UI
+
+- [ ] 7.1 In `Husstand` page (or `Meg` → `Innstillinger`): a small section "Uenighetsgrense" with a slider 1–10 (default 3). Owner sees and can edit; non-owners see read-only.
+- [ ] 7.2 Helper text: "Rader hvor dere er uenige med [N] eller mer markeres."
+- [ ] 7.3 On change: call `setDisagreementThreshold`. Comparison views refetch on next focus.
+
+## 8. Tests
+
+- [ ] 8.1 **Unit (Vitest)**: math edge cases — all weights 0 → null; partial felles → reduced total; rounding consistency at boundary values.
+- [ ] 8.2 **Unit**: disagreement threshold check (`|a - b| >= threshold`).
+- [ ] 8.3 **Integration**: SQL functions return correct totals for hand-built fixture data; partner data leak prevented for non-members.
+- [ ] 8.4 **Integration**: RLS — viewer cannot upsert felles; non-member cannot SELECT felles; threshold update only by owner.
+- [ ] 8.5 **Integration**: cascade — deleting a property removes felles rows.
+- [ ] 8.6 **E2E (Playwright)**: two users score a property differently; second user opens `Sammenligning` and sees the disagreement highlight on the differing row.
+- [ ] 8.7 **E2E**: edit Felles via chip-picker → totalscore panel updates immediately → reload, persists.
+- [ ] 8.8 **E2E**: change threshold from 3 to 2 → matrix highlight pattern changes after refetch.
+- [ ] 8.9 **E2E**: single-member household — comparison tab renders the simplified matrix.
+- [ ] 8.10 **E2E**: viewer mode — Felles cells are not interactive.
+
+## 9. Documentation
+
+- [ ] 9.1 `docs/architecture/comparison.md` — schema, math contract, refresh strategy, role rules.
+- [ ] 9.2 Worked example in the doc: hand-compute felles_total for a sample property to sanity-check the formula.

--- a/openspec/changes/households/.openspec.yaml
+++ b/openspec/changes/households/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/households/README.md
+++ b/openspec/changes/households/README.md
@@ -1,0 +1,3 @@
+# households
+
+Multi-user households with members and invitations - foundation for partner scoring

--- a/openspec/changes/households/design.md
+++ b/openspec/changes/households/design.md
@@ -1,0 +1,119 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Context
+
+Boligscore v2 is a clean-slate rebuild on a new Supabase project. Households are the foundational entity — every other capability (`properties`, `scoring`, `weights`, `comparison`) requires `household_id` ownership. Without households, RLS has nothing to gate on and partner scoring has no meaning.
+
+Key constraints:
+- **Defense-in-depth**: any household member could in principle craft a malicious request. Auth checks must live in the database (RLS), not just the app layer.
+- **Multi-household per user**: a user can be in multiple households (e.g. own with partner, member of family's). The active household is session-scoped UI state.
+- **Clean slate**: no v1 data migration. We can pick the cleanest schema without compatibility constraints.
+- **Mobile-first PWA**: switching households happens via a header chip, not a sidebar.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Model households, members (with roles), and invitations as Supabase tables.
+- Enforce role-based access (`owner` / `member` / `viewer`) at the RLS layer for all writes.
+- Provide an invitation flow that works with copy-paste links (no inbox required) and optional email send.
+- Provide a household switcher UI in the app shell that other capabilities consume.
+- Token-based invitations with a 7-day expiry.
+
+**Non-Goals:**
+- Real-time push of household changes (member added, role changed) to other sessions. Polling/refresh on focus is acceptable for MVP.
+- Custom roles beyond the three defined. No per-permission grants.
+- Cross-household resource sharing (e.g. copying a property to another household). Out of scope.
+- Transferring ownership. MVP: only the original creator is owner; co-owners can be added (multiple owners allowed) but no UI to "promote member to owner" until later.
+- Audit log for household-level actions (member added, role changed). v1 nice-to-have.
+
+## Decisions
+
+### D1. Roles are a string enum, not a permissions table
+
+**Choice**: `household_members.role TEXT CHECK (role IN ('owner', 'member', 'viewer'))`.
+
+**Alternative considered**: flexible `(member, capability) → granted bool` table.
+
+**Rationale**: three roles is enough for MVP and the brief. Flexible permissions add table joins to every RLS check, which is performance overhead and a complexity cost paid forever for a feature we don't need. Easy to migrate to a permissions table later if we ever need finer grain.
+
+### D2. Multiple owners allowed; original creator tracked separately
+
+**Choice**: any user can have `role = 'owner'`. `households.created_by` is the original creator and is **immutable**. Either an owner can be elevated by another owner.
+
+**Rationale**: prevents the "last owner leaves" footgun. If a household has multiple owners, anyone can leave without bricking the household. Brief is silent on this — but the failure mode of "I left and now nobody can manage" is severe enough to design around. Original creator is stored for diagnostics / future "transfer ownership" flow.
+
+### D3. Token-based invitations with `uuid` token + optional email
+
+**Choice**: invitations create a row with a randomly generated UUID `token`. The token alone is sufficient to accept (no email required). Optionally, the inviting user provides an email address and we send an email containing the link `/invitasjon/[token]`.
+
+**Alternative considered**: required email with verification.
+
+**Rationale**: brief explicitly says "Kopier invitasjonslenke" is the primary action — copy-paste is the easiest UX (text the partner the link, no email setup needed). Email is a convenience, not a requirement. A leaked token can be revoked by the inviter (delete row). Single-use enforced by setting `accepted_by` on accept.
+
+### D4. Invitations expire 7 days from creation
+
+**Choice**: `expires_at = created_at + INTERVAL '7 days'`. Hardcoded in default value.
+
+**Rationale**: matches user decision. 7 days is long enough to text and forget, short enough to limit token-leak blast radius. Configurable later if needed.
+
+### D5. Active household is client-side state, scoped to session
+
+**Choice**: the active household is stored in `localStorage` (key: `boligscore.activeHouseholdId`), with the user's most recently accessed household as fallback. Server queries always include the household ID explicitly — no implicit "current household" on the server.
+
+**Alternative considered**: `users.active_household_id` column synced server-side.
+
+**Rationale**: keeps the server stateless w.r.t. UI state. Server endpoints accept `household_id` and verify membership via RLS; the client picks which one. Avoids race conditions where two tabs disagree about active household. Handles the brief's "byttepil øverst" trivially.
+
+### D6. RLS pattern — membership-then-role
+
+**Choice**: every table with `household_id` has two RLS policies:
+1. **Read policy**: `EXISTS (SELECT 1 FROM household_members WHERE household_id = <table>.household_id AND user_id = auth.uid())`. Any role can read.
+2. **Write policy**: same as read PLUS `role IN ('owner', 'member')`. Viewer is excluded.
+
+A helper SQL function `auth.has_household_role(hid uuid, roles text[])` will encapsulate this for reuse.
+
+**Rationale**: simple, fast (the join is on indexed columns), and centralizes the "viewer cannot write" rule. Tested via integration tests that try writes as each role.
+
+### D7. Onboarding creates a household even if user clicks "skip invitation"
+
+**Choice**: a logged-in user always has at least one household. If they skip the invitation step, they still own a household (just with one member — themselves).
+
+**Rationale**: every other capability assumes "active household exists". Defaulting to "everyone has at least one" eliminates a class of empty-state branches across the app. The user can rename or delete it later.
+
+### D8. Household name is freeform; no uniqueness constraint
+
+**Choice**: `households.name TEXT NOT NULL` with no unique index. Two households can both be called "Hjem".
+
+**Rationale**: it's a personal label, not an identifier. Forcing uniqueness creates UX friction with no privacy or correctness benefit.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Last owner leaves, household becomes unmanageable | Multiple owners allowed (D2). Block "leave" action when caller is the only `owner` — UI must promote another member first. |
+| Invitation token leaked (e.g. shared in a public chat) | Inviter can delete pending invitations from `Husstand` page. Tokens expire in 7 days regardless. Single-use after accept. |
+| Viewer attempts a write and bypasses UI guards | RLS denies (D6). UI guards are convenience, not the security boundary. Integration tests verify each role's write attempts are denied at the DB. |
+| User in many households drops the switcher into a tiny dropdown | Acceptable for MVP. If a user is in >5 households we can revisit (search box, etc.). |
+| `localStorage` cleared → active household resets | On boot, fall back to "most recently accessed" (a `last_accessed_at` column on `household_members` updated when active). If user has zero households, route to onboarding. |
+| Two tabs with different active households diverge | Acceptable: each tab acts on its own active household. Cross-tab sync can be added later via `storage` event. |
+| Race: two users accept the same invitation simultaneously | `accepted_by` set via `UPDATE ... WHERE accepted_by IS NULL RETURNING *`. Whoever updates the row first wins; the loser sees a "kunne ikke godta — invitasjonen er allerede brukt" message. |
+
+## Resolved Decisions
+
+### D9. Copy-link only for first launch; email send deferred
+
+**Choice**: MVP ships **copy-link only**. The "Send via e-post" button is deferred to a follow-up change (`households-email-invitations`).
+
+**Rationale**: copy-link is the primary action per the brief. Email send requires Resend setup + DNS verification + transactional-email cost (free tier ~3k/month). Not blocking MVP — most invitations will be sent via SMS/Slack/text anyway.
+
+### D10. Inviter can pick the role when generating an invitation; default `member`
+
+**Choice**: the invitation panel includes a role selector (`member` default, can switch to `owner` or `viewer`). The selected role is stored on the invitation row and applied on acceptance.
+
+**Rationale**: viewers are useful immediately for parents/realtors, and second owners avoid the sole-owner footgun. Surfacing role at send time is a small UI cost for meaningful flexibility. Default of `member` keeps the simple case one-click.
+
+### D11. Hard cascade delete with typed-name confirmation
+
+**Choice**: deleting a household hard-cascades to all dependent rows (members, invitations, properties, scores, weights, etc.) via foreign-key `ON DELETE CASCADE`. The UI requires the user to type the household name to confirm.
+
+**Rationale**: simple schema, matches the "destructive actions = explicit modal" rule in `conventions.md`. Soft delete with grace period is safer but adds a `deleted_at` filter to every read query — not worth it at this scale. The typed-name modal makes accidental deletion implausible.

--- a/openspec/changes/households/proposal.md
+++ b/openspec/changes/households/proposal.md
@@ -1,0 +1,41 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Why
+
+Boligscore v1 is single-user — each account owns its own properties and scores. The core value of v2 is **partner scoring**: two people in the same relationship rate the same property independently and reconcile. Households are the foundation that makes shared property data, partner-aware scoring, and shared weights possible. Without households, none of the v2 flows (compare, felles weights, invite partner) can be built.
+
+## What Changes
+
+- **BREAKING — clean slate**: v2 starts on a **new Supabase project**. v1 data is **not migrated**. Existing v1 users will need to re-register and rebuild their property list.
+- Introduce a `households` entity with: id, name (e.g. "Ine & Kanta"), created_by, created_at.
+- Introduce a `household_members` join with: household_id, user_id, role, joined_at.
+- **Roles**: `owner` | `member` | `viewer`.
+  - `owner`: full read/write + manage members + delete household.
+  - `member`: full read/write on properties, scoring, felles weights, can invite.
+  - `viewer`: read-only — can see properties, scores, comparison; **cannot** score, edit weights, add properties, or invite. Useful for e.g. parents/realtor following along.
+- A user can belong to **multiple** households and switch between them via a chip in the header (e.g. `🏠 Ine & Kanta ▾`).
+- Introduce `household_invitations` with: id, household_id, token (uuid), invited_email (nullable), role (defaults to `member`), expires_at, accepted_by (nullable), created_at.
+- **Invitation expiry: 7 days** from creation.
+- Owner can: rename household, change member roles, remove members, delete household. Members can: leave household. Viewers: same as members for self-management.
+- Invitation flow: owner generates a token → shareable link `/invitasjon/[token]` → invitee accepts and becomes member with the role specified in the invitation. **MVP ships copy-link only**; email-send is deferred to a follow-up change.
+- Supabase RLS: every read/write on properties, scores, weights, etc. must check household membership and respect the role (`viewer` blocked from writes).
+
+## Out of MVP scope (future)
+
+- **Email-send for invitations**: a "Send via e-post" button that delivers the invitation link via Resend. Deferred to a follow-up change (`households-email-invitations`) once Resend is provisioned. MVP relies on the copy-link CTA — users share the link via SMS/Slack/text/etc.
+
+## Capabilities
+
+### New Capabilities
+- `households`: household entity, members, role-based access (owner/member/viewer), invitations with 7-day expiry, household-switching UI.
+
+### Modified Capabilities
+<!-- None - this is the foundational capability that all others depend on. -->
+
+## Impact
+
+- **Database (Supabase)**: new tables `households`, `household_members`, `household_invitations`. All later tables (`properties`, `property_scores`, `weights`, etc.) get a `household_id` foreign key from day 1 — no backfill needed since we're starting fresh.
+- **Auth/RLS**: new policies that gate all access by household membership AND respect role for writes.
+- **UI**: header household-switcher chip; Husstand page (members list with role badges, invitation panel with role selector, leave/delete actions); onboarding step that creates the first household.
+- **Routes**: `/app/onboarding`, `/app/husstand`, `/invitasjon/[token]`.
+- **Dependencies**: blocks `properties`, `scoring`, `weights`, `comparison`, `auth-onboarding`. Should be implemented first.

--- a/openspec/changes/households/specs/households/spec.md
+++ b/openspec/changes/households/specs/households/spec.md
@@ -1,0 +1,228 @@
+## ADDED Requirements
+
+### Requirement: Household creation
+
+The system SHALL allow an authenticated user to create a household by providing a non-empty name. On creation, the creating user SHALL automatically become a member with role `owner`.
+
+#### Scenario: Successful creation
+
+- **WHEN** an authenticated user submits a household-create request with `name = "Ine & Kanta"`
+- **THEN** a `households` row is inserted with `name = "Ine & Kanta"`, `created_by = <user-id>`, and `created_at = now()`
+- **AND** a `household_members` row is inserted with `household_id = <new household>`, `user_id = <user-id>`, `role = 'owner'`, `joined_at = now()`
+- **AND** the response returns the new household's id
+
+#### Scenario: Empty name rejected
+
+- **WHEN** an authenticated user submits a household-create request with `name = ""` or only whitespace
+- **THEN** the system rejects the request with a validation error
+- **AND** no `households` or `household_members` row is inserted
+
+#### Scenario: Unauthenticated request rejected
+
+- **WHEN** an unauthenticated request attempts to create a household
+- **THEN** the system rejects with an auth error and no rows are inserted
+
+### Requirement: Household membership roles
+
+Every `household_members` row SHALL have exactly one of three roles: `owner`, `member`, or `viewer`. A household MAY have multiple owners. A user MAY belong to multiple households simultaneously.
+
+#### Scenario: Allowed role values
+
+- **WHEN** a `household_members` row is inserted with `role = 'owner' | 'member' | 'viewer'`
+- **THEN** the insert succeeds
+
+#### Scenario: Invalid role rejected
+
+- **WHEN** a `household_members` row is inserted with `role = 'admin'` or any value outside the allowed set
+- **THEN** the database CHECK constraint rejects the insert
+
+#### Scenario: User can belong to multiple households
+
+- **WHEN** user U is already a member of household A
+- **AND** U accepts an invitation to household B
+- **THEN** U is a member of both A and B
+- **AND** queries scoped to A return only A's data
+
+### Requirement: Role-based access control
+
+Reads on tables with `household_id` SHALL be permitted to any role of a member of that household. Writes SHALL be restricted to `owner` and `member` only; `viewer` writes MUST be denied at the database (RLS) layer regardless of UI.
+
+#### Scenario: Owner can write
+
+- **WHEN** a user with `role = 'owner'` attempts to insert/update/delete a row in a household-scoped table for their household
+- **THEN** the operation succeeds
+
+#### Scenario: Member can write
+
+- **WHEN** a user with `role = 'member'` attempts to insert/update/delete a row in a household-scoped table for their household
+- **THEN** the operation succeeds
+
+#### Scenario: Viewer write denied at RLS
+
+- **WHEN** a user with `role = 'viewer'` attempts to insert/update/delete a row in a household-scoped table for their household
+- **THEN** the database returns an RLS policy violation error
+- **AND** no row is created/modified/removed
+
+#### Scenario: Non-member read denied
+
+- **WHEN** a user who is not a member of household H attempts to read a row in a household-scoped table where `household_id = H`
+- **THEN** the database returns no rows
+
+### Requirement: Household name and metadata management
+
+An `owner` SHALL be able to update the household's `name`. The `created_by` field MUST be immutable after insert.
+
+#### Scenario: Owner renames household
+
+- **WHEN** an `owner` updates `households.name` to a non-empty value
+- **THEN** the update succeeds
+
+#### Scenario: Member cannot rename
+
+- **WHEN** a `member` or `viewer` attempts to update `households.name`
+- **THEN** the operation is denied by RLS
+
+#### Scenario: created_by is immutable
+
+- **WHEN** any user attempts to update `households.created_by`
+- **THEN** the operation is denied (database trigger or column-level RLS)
+
+### Requirement: Invitation creation
+
+An `owner` or `member` SHALL be able to create an invitation that produces a unique token and an `expires_at` of 7 days from creation. The role granted on acceptance SHALL be configurable at invitation time and default to `member`.
+
+#### Scenario: Owner creates an invitation with default role
+
+- **WHEN** an `owner` creates an invitation for their household without specifying a role
+- **THEN** a `household_invitations` row is inserted with a fresh UUID `token`, `expires_at = now() + interval '7 days'`, `accepted_by = null`, `role = 'member'`
+
+#### Scenario: Inviter selects role explicitly
+
+- **WHEN** an `owner` or `member` creates an invitation and selects role `viewer` (or `owner`)
+- **THEN** the row is inserted with the selected role
+- **AND** acceptance grants the invitee that role
+
+#### Scenario: Member creates an invitation
+
+- **WHEN** a `member` creates an invitation for their household
+- **THEN** the row is inserted with default role `member` (or the explicitly selected role)
+
+#### Scenario: Viewer cannot create invitation
+
+- **WHEN** a `viewer` attempts to create an invitation
+- **THEN** RLS denies the insert
+
+#### Scenario: Copy-link is the only delivery mechanism in MVP
+
+- **WHEN** an invitation is created
+- **THEN** the system surfaces the link `${origin}/invitasjon/<token>` for the inviter to copy
+- **AND** no email is sent (email-send is deferred to a follow-up change)
+
+### Requirement: Invitation acceptance
+
+A user SHALL be able to accept an invitation by visiting `/invitasjon/[token]` while authenticated. Acceptance SHALL be atomic and single-use — the row's `accepted_by` is set in a single update that fails if already accepted.
+
+#### Scenario: Successful acceptance
+
+- **WHEN** an authenticated user U visits `/invitasjon/<token>` for an invitation that is unexpired and unaccepted
+- **AND** U confirms with the "Bli med" button
+- **THEN** `household_invitations.accepted_by = U` is set
+- **AND** a `household_members` row is inserted with `household_id`, `user_id = U`, `role = <invitation.role>`, `joined_at = now()`
+- **AND** U is redirected to `/app` with the new household active
+
+#### Scenario: Expired invitation
+
+- **WHEN** an authenticated user visits `/invitasjon/<token>` for an invitation where `expires_at < now()`
+- **THEN** the system displays "Denne lenken har utløpt. Be om en ny."
+- **AND** no `household_members` row is created
+
+#### Scenario: Already accepted invitation
+
+- **WHEN** a user visits `/invitasjon/<token>` for an invitation where `accepted_by IS NOT NULL`
+- **THEN** the system displays a message that the invitation has already been used
+- **AND** no `household_members` row is created
+
+#### Scenario: User already a member
+
+- **WHEN** an authenticated user visits a valid `/invitasjon/<token>` for a household they are already a member of
+- **THEN** the system displays "Du er allerede medlem av denne husholdningen"
+- **AND** the invitation is **not** marked accepted (so the inviter can still use it for someone else)
+
+#### Scenario: Unauthenticated user redirected
+
+- **WHEN** an unauthenticated user visits `/invitasjon/<token>`
+- **THEN** the system redirects to `/registrer` (or `/logg-inn`) with the invitation URL stored as the post-login destination
+- **AND** after authentication the user is returned to the invitation acceptance screen
+
+#### Scenario: Race — concurrent acceptance
+
+- **WHEN** two users simultaneously attempt to accept the same invitation
+- **THEN** at most one acceptance succeeds (atomic `UPDATE ... WHERE accepted_by IS NULL`)
+- **AND** the other user receives the "already accepted" message
+
+### Requirement: Membership management
+
+An `owner` SHALL be able to remove members and change member roles (subject to the "must keep at least one owner" constraint). Members SHALL be able to leave the household themselves.
+
+#### Scenario: Owner removes a member
+
+- **WHEN** an `owner` removes a `member` or `viewer` from their household
+- **THEN** the `household_members` row is deleted
+
+#### Scenario: Owner changes a member's role
+
+- **WHEN** an `owner` updates another member's `role` to one of the allowed values
+- **THEN** the update succeeds
+
+#### Scenario: Member leaves household
+
+- **WHEN** a `member` or `viewer` deletes their own `household_members` row
+- **THEN** the operation succeeds and they no longer have access
+
+#### Scenario: Owner attempts to leave when sole owner
+
+- **WHEN** an `owner` attempts to delete their own membership
+- **AND** they are the only `owner` of the household
+- **THEN** the operation is denied with the message "Du må først gjøre noen andre til eier før du kan forlate husholdningen"
+
+#### Scenario: Owner leaves when other owners exist
+
+- **WHEN** an `owner` deletes their own membership
+- **AND** at least one other member has `role = 'owner'`
+- **THEN** the operation succeeds
+
+### Requirement: Household deletion
+
+An `owner` SHALL be able to delete their household. Deletion SHALL cascade to remove all `household_members`, `household_invitations`, and any household-scoped data (`properties`, `property_scores`, `weights`, etc.) defined by other capabilities.
+
+#### Scenario: Owner deletes household
+
+- **WHEN** an `owner` deletes their household after typed-name confirmation
+- **THEN** the `households` row is deleted
+- **AND** all dependent rows in `household_members`, `household_invitations`, and household-scoped tables from other capabilities are deleted via foreign key cascade
+
+#### Scenario: Member cannot delete household
+
+- **WHEN** a `member` or `viewer` attempts to delete the household
+- **THEN** RLS denies the operation
+
+### Requirement: Active household selection
+
+The client SHALL maintain an "active household" id and pass it explicitly with each scoped query. The active household SHALL be persisted in `localStorage`. On first login the most recently joined household SHALL be active.
+
+#### Scenario: First login defaults to most recent membership
+
+- **WHEN** a user logs in and `localStorage.activeHouseholdId` is not set
+- **THEN** the client picks the household with the most recent `household_members.joined_at`
+
+#### Scenario: User switches active household
+
+- **WHEN** a user selects a different household from the switcher chip
+- **THEN** `localStorage.activeHouseholdId` is updated to the selected id
+- **AND** all subsequent scoped queries use the new id
+
+#### Scenario: Active household no longer accessible
+
+- **WHEN** a user attempts to use an `activeHouseholdId` they are no longer a member of (e.g. removed by an owner in another tab)
+- **THEN** the next scoped query returns no rows
+- **AND** the client falls back to the most recent remaining membership, or routes to onboarding if the user has zero memberships

--- a/openspec/changes/households/tasks.md
+++ b/openspec/changes/households/tasks.md
@@ -1,0 +1,108 @@
+> Conventions: see `openspec/conventions.md`.
+
+## 1. Project bootstrap (prerequisite if not done)
+
+- [ ] 1.1 Provision a fresh Supabase project for v2 and store URL/anon key in `.env.local`.
+- [ ] 1.2 Confirm Next.js (App Router) skeleton exists (delivered by `navigation-shell` capability — depend on its early scaffolding).
+- [ ] 1.3 Add Supabase JS client (`@supabase/supabase-js`, `@supabase/ssr`) and a typed client factory (`lib/supabase/server.ts`, `lib/supabase/client.ts`).
+- [ ] 1.4 Run `supabase init` and start `supabase start` locally; confirm Mailpit is reachable at `http://localhost:54324`.
+
+## 2. Database schema (SQL migration)
+
+- [ ] 2.1 Create migration `supabase/migrations/<ts>_households.sql`.
+- [ ] 2.2 Create `households` table: `id uuid PK default gen_random_uuid()`, `name text NOT NULL CHECK (length(trim(name)) > 0)`, `created_by uuid NOT NULL REFERENCES auth.users(id)`, `created_at timestamptz NOT NULL default now()`, `comparison_disagreement_threshold int NOT NULL default 3 CHECK (comparison_disagreement_threshold BETWEEN 1 AND 10)`.
+- [ ] 2.3 Create `household_role` enum / domain: `('owner', 'member', 'viewer')`. Use a CHECK constraint on a TEXT column for portability.
+- [ ] 2.4 Create `household_members` table: `household_id uuid REFERENCES households(id) ON DELETE CASCADE`, `user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE`, `role text NOT NULL CHECK (role IN ('owner','member','viewer'))`, `joined_at timestamptz NOT NULL default now()`, `last_accessed_at timestamptz NOT NULL default now()`. Composite PK `(household_id, user_id)`. Index on `user_id`.
+- [ ] 2.5 Create `household_invitations` table: `id uuid PK default gen_random_uuid()`, `household_id uuid REFERENCES households(id) ON DELETE CASCADE`, `token uuid NOT NULL UNIQUE default gen_random_uuid()`, `invited_email text`, `role text NOT NULL CHECK (role IN ('owner','member','viewer')) default 'member'`, `expires_at timestamptz NOT NULL default (now() + interval '7 days')`, `accepted_by uuid REFERENCES auth.users(id)`, `created_by uuid NOT NULL REFERENCES auth.users(id)`, `created_at timestamptz NOT NULL default now()`. Index on `token`.
+- [ ] 2.6 Add a trigger preventing updates to `households.created_by` (raise exception).
+
+## 3. RLS policies
+
+- [ ] 3.1 Enable RLS on all three tables.
+- [ ] 3.2 Create SQL function `public.has_household_role(hid uuid, roles text[])` returning bool, defined as `SELECT EXISTS(SELECT 1 FROM household_members WHERE household_id = hid AND user_id = auth.uid() AND role = ANY(roles))`. Mark `STABLE` and `SECURITY DEFINER`.
+- [ ] 3.3 `households` policies:
+  - SELECT: `EXISTS (SELECT 1 FROM household_members WHERE household_id = households.id AND user_id = auth.uid())`.
+  - INSERT: any authenticated user (creator becomes owner via app code or trigger).
+  - UPDATE: `has_household_role(id, ARRAY['owner'])`.
+  - DELETE: `has_household_role(id, ARRAY['owner'])`.
+- [ ] 3.4 `household_members` policies:
+  - SELECT: must be a member of the same household.
+  - INSERT: only via accept-invitation server action OR by an owner.
+  - UPDATE (role change): `has_household_role(household_id, ARRAY['owner'])`.
+  - DELETE (remove/leave): self OR owner.
+- [ ] 3.5 `household_invitations` policies:
+  - SELECT: members of the household OR token-by-token public read for acceptance flow (handled via a `SECURITY DEFINER` function so anonymous can fetch by token).
+  - INSERT: `has_household_role(household_id, ARRAY['owner','member'])`.
+  - UPDATE (mark accepted): the accepting user only, and only if `accepted_by IS NULL` and `expires_at > now()`.
+  - DELETE: owner or the original inviter.
+
+## 4. Server actions / data layer
+
+- [ ] 4.1 `createHousehold(name)` — Next.js Server Action. Inserts household + first owner membership in a transaction.
+- [ ] 4.2 `renameHousehold(id, name)` — checks role via RLS.
+- [ ] 4.3 `deleteHousehold(id)` — owner only, requires typed-name confirmation on client.
+- [ ] 4.4 `listMyHouseholds()` — returns `[{id, name, role, joined_at, last_accessed_at}]` for the current user.
+- [ ] 4.5 `getHousehold(id)` — fetch single household + member list with roles.
+- [ ] 4.6 `setMemberRole(householdId, userId, role)` — owner only.
+- [ ] 4.7 `removeMember(householdId, userId)` — owner only.
+- [ ] 4.8 `leaveHousehold(householdId)` — self only. Server-side check: deny if caller is sole owner; return error message in Norwegian.
+- [ ] 4.9 `createInvitation(householdId, role?, invitedEmail?)` — generates token, optionally sends email.
+- [ ] 4.10 `getInvitationByToken(token)` — RPC via `SECURITY DEFINER` so unauthenticated users can read enough to render the acceptance page (returns: household name, inviter name, role, expires_at; never the token row directly).
+- [ ] 4.11 `acceptInvitation(token)` — atomic update: `UPDATE household_invitations SET accepted_by = auth.uid() WHERE token = $1 AND accepted_by IS NULL AND expires_at > now() RETURNING household_id, role`. Then insert `household_members` row.
+- [ ] 4.12 `revokeInvitation(invitationId)` — owner or original creator can delete unaccepted invitations.
+
+## 5. Email integration — DEFERRED to follow-up change `households-email-invitations`
+
+MVP ships **copy-link only**. The "Send via e-post" button is **not** rendered in the MVP UI; users share the link via SMS/Slack/text. The tasks below stay here as a reference for the follow-up change but are **not** part of this change's done-criteria.
+
+- [ ] ~~5.1 Add `RESEND_API_KEY` to env (prod) and a Resend templates module under `lib/email/`.~~ (deferred)
+- [ ] ~~5.2 Implement `sendInvitationEmail({ to, inviterName, householdName, link })`.~~ (deferred)
+- [ ] ~~5.3 Email body: Norwegian copy.~~ (deferred)
+
+## 6. UI — Husstand page (`/app/husstand`)
+
+- [ ] 6.1 Page lists active household: name (editable for owner), member list with role badges and "fjern" / "endre rolle" actions for owners.
+- [ ] 6.2 Invitation panel: "Kopier lenke" (primary, copies `${origin}/invitasjon/${token}` to clipboard). Role selector (default `member`, options `owner` / `member` / `viewer`) when generating a new invitation. **No "Send via e-post" button in MVP** — deferred to follow-up change.
+- [ ] 6.3 Pending invitations list with revoke action.
+- [ ] 6.4 Danger zone (owner only): "Slett husholdning" with typed-name confirmation modal.
+- [ ] 6.5 "Forlat husholdning" action (visible to non-sole-owner members).
+- [ ] 6.6 All status / role indicators use icon + text + color (per a11y rules in conventions.md).
+
+## 7. UI — Household switcher
+
+- [ ] 7.1 Component `<HouseholdSwitcher />` rendered in the app shell header (delivered by `navigation-shell` but the component itself ships here).
+- [ ] 7.2 Chip displays active household name with house emoji and dropdown caret.
+- [ ] 7.3 Dropdown lists all memberships with role badges + "Opprett ny husholdning" (routes to `/app/onboarding`).
+- [ ] 7.4 Selecting a household updates `localStorage.activeHouseholdId`, calls a server action to bump `household_members.last_accessed_at`, and re-renders the active route.
+- [ ] 7.5 If user has zero memberships, redirect to `/app/onboarding`.
+
+## 8. UI — Onboarding (`/app/onboarding`)
+
+- [ ] 8.1 Form with single `name` input. Submit calls `createHousehold`.
+- [ ] 8.2 Post-create screen: "Kopier invitasjonslenke" (primary), "Send via e-post" (secondary), "Hopp over" (skip).
+- [ ] 8.3 Skip routes to `/app` (empty state).
+- [ ] 8.4 Auto-runs after first signup if `listMyHouseholds()` returns empty.
+
+## 9. UI — Invitation acceptance (`/invitasjon/[token]`)
+
+- [ ] 9.1 Server-render the invitation summary via `getInvitationByToken`. Show household name, inviter, role, expiry.
+- [ ] 9.2 If unauthenticated: redirect to `/registrer?next=/invitasjon/<token>`.
+- [ ] 9.3 If expired / already accepted: show error variant with the right Norwegian message.
+- [ ] 9.4 If user is already a member: show "Du er allerede medlem" + button to switch active household.
+- [ ] 9.5 "Bli med" button calls `acceptInvitation`. On success, set `localStorage.activeHouseholdId` to the new household and redirect to `/app`.
+
+## 10. Tests
+
+- [ ] 10.1 **Unit (Vitest)**: role helper functions, sole-owner check, invitation expiry helper, name validator.
+- [ ] 10.2 **Integration (Vitest + Supabase local)**: RLS — for each role (owner/member/viewer), verify allowed operations succeed and forbidden ones fail (read, write on each household-scoped table). Race-condition test for concurrent invitation acceptance.
+- [ ] 10.3 **Integration**: `acceptInvitation` atomicity (two simultaneous calls — exactly one succeeds).
+- [ ] 10.4 **Integration**: cascade delete — deleting a household removes members, invitations, and household-scoped data from other tables.
+- [ ] 10.5 **E2E (Playwright)**: full invite-and-accept flow — Alice creates household, copies link, opens new browser context as Bob, accepts, both see same household. Switcher works.
+- [ ] ~~10.6 **E2E**: Mailpit-based invitation email — Alice sends invitation by email, test reads Mailpit's HTTP API, follows the link as Bob, accepts, verifies membership.~~ (deferred with email-send follow-up change)
+- [ ] 10.7 **E2E**: viewer attempts to add a property → UI blocks AND a direct API call would fail RLS (curl/test with viewer JWT).
+
+## 11. Documentation
+
+- [ ] 11.1 Update root `README.md` with Supabase CLI local-dev section (Mailpit URL, seed command).
+- [ ] 11.2 Update `README.md` with role explanation table (owner / member / viewer).
+- [ ] 11.3 Add a short `docs/architecture/households.md` summarizing the RLS model and `has_household_role` helper for future contributors.

--- a/openspec/changes/navigation-shell/.openspec.yaml
+++ b/openspec/changes/navigation-shell/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/navigation-shell/README.md
+++ b/openspec/changes/navigation-shell/README.md
@@ -1,0 +1,3 @@
+# navigation-shell
+
+Mobile-first PWA shell with bottom nav, tabs, and household switcher

--- a/openspec/changes/navigation-shell/design.md
+++ b/openspec/changes/navigation-shell/design.md
@@ -1,0 +1,109 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Context
+
+v1 is a single Vite SPA with one root component. v2 needs **routes** (per-property tabs, top-level pages, public marketing route, invitation acceptance), **PWA installability**, **light/dark theme**, and a **design system** that aligns with Stitch screens. The shell is the chassis every other capability hangs on — its decisions are reused everywhere, so picking the right framework and tokens here matters more than any single feature decision.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Migrate to Next.js (App Router) and replace `App.tsx` with a routed layout.
+- Provide a single responsive layout: same component tree on mobile and desktop, scaling via Tailwind breakpoints. Mobile-first, desktop = single column with max width.
+- Bottom navigation on mobile (Boliger / Vekter / Husstand / Meg) anchored to viewport bottom.
+- Per-property tab system (`Oversikt | Min vurdering | Sammenligning | Kommentarer | Notater`) using nested routes.
+- PWA: manifest + icons + offline shell via service worker. Installable on mobile.
+- Theme: light (default) + dark, explicit toggle, persisted, no flash on reload.
+- Design tokens (spacing, type, color) extracted from Stitch screens and codified as Tailwind config + CSS variables.
+- Route guards that redirect unauthenticated users to `/logg-inn` for `/app/*` paths.
+
+**Non-Goals:**
+- Auto theme following `prefers-color-scheme`. Explicit toggle only.
+- Separate desktop nav (sidebar). One nav, both viewports.
+- Offline write queueing — show banner when offline, disable writes, sync on reconnect is a future change.
+- Server-side data fetching for every page — most pages remain client-rendered with Supabase JS. SSR is reserved for SEO-relevant public pages (`/`, `/invitasjon/[token]`).
+
+## Decisions
+
+### D1. Next.js App Router
+
+**Choice**: Next.js 14+ with App Router (`app/` directory).
+
+**Alternative considered**: Next.js Pages Router; React Router on existing Vite.
+
+**Rationale**: App Router gives us server components (cleaner SSR for landing/invitation pages), nested layouts (perfect for `/app/bolig/[id]/<tab>`), file-based routing, and Vercel-native deploy. Pages Router is older and less aligned with where Next.js is going. React Router on Vite would work but we'd reimplement layouts/data-loading patterns Next.js already solves.
+
+### D2. PWA via `@ducanh2912/next-pwa`
+
+**Choice**: `@ducanh2912/next-pwa` (App Router-compatible fork of `next-pwa`).
+
+**Alternative considered**: hand-rolled service worker via `next/cache` and Workbox directly.
+
+**Rationale**: battle-tested, generates manifest registration + service worker, handles versioning. App Router compatibility via the maintained fork. Hand-rolling is unjustified complexity for an MVP.
+
+### D3. Theme: CSS variables in `:root[data-theme=...]`, Tailwind reads via config
+
+**Choice**: define color tokens as CSS variables (`--color-bg`, `--color-fg`, `--color-primary`, etc.) under `:root[data-theme="light"]` and `:root[data-theme="dark"]`. Tailwind config maps semantic class names (`bg-surface`, `text-fg`, `border-muted`) to those variables. Theme switch toggles `data-theme` attribute on `<html>`.
+
+**Alternative considered**: Tailwind `dark:` variant prefix everywhere.
+
+**Rationale**: semantic class names (`bg-surface` not `bg-white dark:bg-slate-900`) keep components theme-agnostic. Easier to add a third theme later. CSS variables are also consumable by inline styles when needed.
+
+### D4. No-FOUC theme: inline script in `<head>`
+
+**Choice**: a tiny script in the root layout's `<head>` reads `localStorage.theme` and sets `data-theme` on `<html>` before React hydrates. Falls back to `light` if unset.
+
+**Rationale**: any theme logic that runs after hydration causes a flash of unstyled content (white flash → dark theme paint). Inline script is the standard fix and runs before paint.
+
+### D5. Bottom nav is `position: fixed` with `padding-bottom` on `<main>`
+
+**Choice**: bottom nav fixed to viewport bottom on all viewports. Main content gets `pb-[<nav-height>]` so the nav doesn't overlap. On desktop the same nav stays at the bottom — keeps one component, one mental model.
+
+**Alternative considered**: top tab bar on desktop.
+
+**Rationale**: brief says desktop is secondary. Single nav is less code, less drift, fewer bugs. If it ever feels wrong on desktop we can revisit.
+
+### D6. Property detail tabs via nested routes
+
+**Choice**: `/app/bolig/[id]/oversikt`, `/app/bolig/[id]/min-vurdering`, etc. Each tab is its own route segment. Default redirect from `/app/bolig/[id]` to `/oversikt`. The `[id]` layout renders the tab strip and the slot for the active tab.
+
+**Alternative considered**: query string state (`/app/bolig/[id]?tab=oversikt`); parallel routes.
+
+**Rationale**: real routes mean back-button works per tab, deep links work, and SSR can prefetch only the active tab's data. Parallel routes are overkill for "show one of N panes". Query strings make analytics and bookmarks fuzzy.
+
+### D7. Breakpoint at 768px (Tailwind `md:`)
+
+**Choice**: mobile = `< 768px`, desktop = `≥ 768px`. Use Tailwind's `md:` prefix for desktop adjustments.
+
+**Rationale**: matches Tailwind defaults, matches typical tablet-portrait threshold, keeps mental model simple. Brief describes "mobil" and "desktop" — no tablet-specific layout.
+
+### D8. PWA install: passive, surfaced only in Meg page
+
+**Choice**: capture the `beforeinstallprompt` event but **don't** show a custom prompt automatically. Add an "Installer som app" button on the `Meg` page that fires the saved event when clicked.
+
+**Rationale**: aggressive install prompts annoy users. Brief says "tone: rolig, ryddig, trygg" — pushing install fights that. Surface it where users go to configure things.
+
+### D9. Deployment target: Vercel
+
+**Choice**: Vercel for staging + production.
+
+**Rationale**: Next.js native deploy, free hobby tier covers MVP, preview deployments per PR are useful for agent-loop reviews. Can move later if needed.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Migrating Vite → Next.js touches every file | Do it on a fresh branch, port file-by-file, keep v1 in `/legacy/` for reference until v2 ships, then delete. |
+| Service worker caches stale assets after deploy | `next-pwa` handles versioning via build hash; document `Ctrl+F5` workaround for dev confusion in `README`. |
+| Theme FOUC despite the inline script | Inline script runs synchronously before paint — verified by Chrome DevTools Performance trace as part of e2e. |
+| Tab routing breaks deep links if a tab is renamed | Tab slugs are stable and listed in conventions.md. Renaming requires a migration note. |
+| Bottom nav covers content on small viewports | `pb-20` (or similar) on `<main>`; integration test scrolls to bottom and asserts last item is fully visible. |
+| Stitch design tokens drift from implementation | Document the token-extraction process in `tasks.md` step 2; rerun extraction whenever Stitch screens are updated. |
+| `/dev/login` ships to prod | Build guard: `if (process.env.NODE_ENV === 'production' && !process.env.DEV_LOGIN_FORCE) throw new Error('dev/login disabled')`. CI test asserts route returns 404 in prod build. |
+
+## Resolved Decisions
+
+### D10. Tailwind version
+
+**Choice**: Tailwind v3 (stable). Defer Tailwind v4 until it's out of preview.
+
+**Rationale**: stability over freshness. Tooling around v3 is mature.

--- a/openspec/changes/navigation-shell/proposal.md
+++ b/openspec/changes/navigation-shell/proposal.md
@@ -1,0 +1,58 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Why
+
+v1 is a single-page app where every action opens a modal — fine on desktop, miserable on mobile, and impossible to grow into the multi-page v2 flows (per-property tabs, Vekter/Husstand/Meg pages, household switcher). v2 is **mobile-first as a PWA** because the primary use-case is "I'm standing in someone's kitchen at a viewing." This capability provides the navigation chassis everything else hangs on: bottom nav, per-property tabs, household switcher, theme, and PWA installability. **The repo migrates from Vite/React-only to Next.js (App Router)** to get routing, server components, API routes (needed later for FINN-import), and PWA tooling in one stack.
+
+## What Changes
+
+- **BREAKING — framework migration**: replace the current Vite + React single-page app with **Next.js (App Router)**. All existing components are ported into `/app/*` route segments.
+- **Mobile-first design**, with desktop = responsive single-column with a max-width centered layout. **Same navigation on both** (bottom nav on mobile, same nav stretched/anchored on desktop). No separate side-nav variant — keeps things simple and the brief says desktop is secondary.
+- **Bottom nav** (mobile) / equivalent at-the-bottom or top nav on desktop, four items:
+  - `Boliger` (forsiden, list of household properties)
+  - `Vekter`
+  - `Husstand`
+  - `Meg`
+- **Household switcher** at the top of every page: chip showing active household name (e.g. `🏠 Ine & Kanta ▾`). Dropdown lists all households the user belongs to + "Opprett ny husholdning".
+- **Property detail tabs**: `Oversikt` | `Min vurdering` | `Sammenligning` | `Kommentarer` | `Notater`. Underline-style, horizontally scrollable on mobile if overflow.
+- **PWA**:
+  - Manifest with name, icons (192/512), theme colors, `display: standalone`, `start_url: /app`.
+  - Service worker for offline shell + asset caching (no offline mutations in MVP — show "du er offline" banner).
+  - Installable on mobile home screen.
+  - Implementation: `next-pwa` or equivalent App-Router-compatible PWA plugin.
+- **Theming**: **light** (default) and **dark** — explicit toggle, no auto/system mode in MVP. Stored in `Meg` page, persisted to localStorage + user profile (when logged in). CSS variables, no flash on reload (handled by SSR/server component).
+- **Mobile-first principles** (enforced via design tokens / lint):
+  - Touch targets ≥ 44×44px.
+  - No hover-only interactions.
+  - One-handed reach: primary CTAs in bottom half / FAB.
+  - FAB on `Boliger` page for `+ Ny bolig`.
+- **Accessibility floors**:
+  - Contrast AA minimum.
+  - Status never communicated by color alone — always icon + text.
+  - Visible focus ring on tab navigation.
+- **Design tokens** (spacing, type, color palette) are sourced from the **Stitch** designs. Each Stitch screen will be pulled, palette/typography extracted, and codified as CSS variables / Tailwind config. This is part of the implementation tasks for this capability.
+
+## Capabilities
+
+### New Capabilities
+- `navigation-shell`: Next.js app shell, bottom/top nav, household switcher, per-property tab system, PWA setup, light/dark theme toggle, design tokens extracted from Stitch, accessibility floor.
+
+### Modified Capabilities
+<!-- None - this is new chassis, not a modification of existing nav. -->
+
+## Out of MVP scope (future)
+
+- **Auto theme** following `prefers-color-scheme`. MVP is explicit toggle only.
+- **Offline mutations** — write queueing while offline, sync on reconnect. MVP shows a banner and disables writes when offline.
+- **Per-device theme override** distinct from profile preference.
+
+## Impact
+
+- **Framework migration**: Vite → Next.js (App Router). Significant restructure: `App.tsx` → `app/layout.tsx` + route segments. All existing components keep their shape but lose modal-based composition.
+- **Layout**: new `<AppShell>` wrapping all `/app/*` routes; `<PropertyTabs>` wrapping `/app/bolig/[id]/*` routes.
+- **PWA tooling**: add `next-pwa` (or App-Router-compatible alternative), generate manifest + icons, register service worker.
+- **Theme**: theme provider with two themes (light/dark), CSS variables for colors, persist preference in localStorage (anonymous) + sync to user profile when logged in.
+- **Design tokens**: spacing scale, type scale, color palette aligned with brief (rolig blå/dempet grønn primary, varm grå nøytral, pastell statusfarger). Extracted from Stitch via the `mcp__stitch__get_screen` tool during implementation.
+- **Routes added**: `/`, `/registrer`, `/logg-inn`, `/app/onboarding`, `/app`, `/app/vekter`, `/app/husstand`, `/app/meg`, `/app/bolig/ny`, `/app/bolig/[id]/{oversikt,min-vurdering,sammenligning,kommentarer,notater}`, `/invitasjon/[token]`.
+- **Build/deploy**: existing Vite build pipeline replaced. Deploy target likely Vercel (Next.js native) or Netlify.
+- **Dependencies**: should be done early (alongside `households` + `auth-onboarding`) since every other capability mounts inside this shell. Doesn't block scoring/weights logic, but blocks their *UI delivery*.

--- a/openspec/changes/navigation-shell/specs/navigation-shell/spec.md
+++ b/openspec/changes/navigation-shell/specs/navigation-shell/spec.md
@@ -1,0 +1,175 @@
+## ADDED Requirements
+
+### Requirement: Application shell layout
+
+The system SHALL render an application shell that wraps all `/app/*` routes with: a header containing the household switcher, a main content area, and a bottom navigation bar with four destinations.
+
+#### Scenario: Shell renders on app routes
+
+- **WHEN** an authenticated user visits any `/app/*` route
+- **THEN** the page renders the shell: header (with household switcher), main content area, bottom nav with `Boliger`, `Vekter`, `Husstand`, `Meg`
+
+#### Scenario: Shell does not render on public routes
+
+- **WHEN** a user visits `/`, `/registrer`, `/logg-inn`, or `/invitasjon/[token]`
+- **THEN** the public layout is used (no household switcher, no bottom nav)
+
+### Requirement: Bottom navigation
+
+The bottom navigation SHALL be fixed to the viewport bottom on both mobile and desktop, contain four equal-width destinations, and indicate the active destination visually (filled icon + accent color).
+
+#### Scenario: Active destination is highlighted
+
+- **WHEN** the user is on `/app/vekter`
+- **THEN** the `Vekter` nav item displays its filled-icon variant and an accent-colored label
+
+#### Scenario: Tap navigates without full reload
+
+- **WHEN** the user taps another nav destination
+- **THEN** the route changes via client-side navigation (no full page reload)
+
+#### Scenario: Main content has bottom padding equal to nav height
+
+- **WHEN** the user scrolls main content to the very bottom
+- **THEN** the last item is fully visible (not occluded by the bottom nav)
+
+### Requirement: Property detail tab system
+
+The property detail page SHALL render a tab strip with five tabs: `Oversikt`, `Min vurdering`, `Sammenligning`, `Kommentarer`, `Notater`. Each tab SHALL be a distinct route. Visiting `/app/bolig/[id]` without a tab segment SHALL redirect to `/app/bolig/[id]/oversikt`.
+
+#### Scenario: Default redirect to Oversikt
+
+- **WHEN** a user visits `/app/bolig/123`
+- **THEN** they are redirected to `/app/bolig/123/oversikt`
+
+#### Scenario: Tab switch updates URL
+
+- **WHEN** a user is on `/app/bolig/123/oversikt` and taps the `Min vurdering` tab
+- **THEN** the URL becomes `/app/bolig/123/min-vurdering` and the tab content swaps
+
+#### Scenario: Browser back returns to previous tab
+
+- **WHEN** a user navigates from `Oversikt` to `Min vurdering` and presses browser back
+- **THEN** they return to `Oversikt`
+
+#### Scenario: Direct deep link to a tab
+
+- **WHEN** a user opens `/app/bolig/123/sammenligning` directly (cold load)
+- **THEN** the page renders with the `Sammenligning` tab active
+
+### Requirement: Light/dark theme
+
+The system SHALL support exactly two themes (`light`, `dark`). The active theme SHALL be persisted in `localStorage.theme` and applied via the `data-theme` attribute on `<html>` before first paint, eliminating any flash of incorrect theme.
+
+#### Scenario: Default theme on first visit
+
+- **WHEN** a user has no `localStorage.theme` value and visits the site
+- **THEN** the page renders with `data-theme="light"`
+
+#### Scenario: Theme toggle persists
+
+- **WHEN** the user toggles to dark mode in `Meg`
+- **THEN** `localStorage.theme = "dark"` is set
+- **AND** `<html>` gains `data-theme="dark"`
+
+#### Scenario: Theme survives reload without flash
+
+- **WHEN** a user with `localStorage.theme = "dark"` reloads any page
+- **THEN** the page paints in dark theme with no observable flash to light theme during load
+
+### Requirement: PWA installability
+
+The site SHALL ship a web app manifest, two icon sizes (192px and 512px), and a service worker that caches the application shell for offline navigation. The site SHALL satisfy browser-level installability criteria.
+
+#### Scenario: Manifest is served
+
+- **WHEN** the browser requests `/manifest.webmanifest`
+- **THEN** the response is a valid manifest with `name`, `short_name`, `icons` (192 + 512), `display: standalone`, `start_url: /app`, `theme_color`, `background_color`
+
+#### Scenario: Service worker registers
+
+- **WHEN** a user visits the site for the first time
+- **THEN** the service worker is registered and caches the application shell
+
+#### Scenario: Install action available in Meg
+
+- **WHEN** the browser fires `beforeinstallprompt` and the user later visits `/app/meg`
+- **THEN** an "Installer som app" button is shown
+- **AND** clicking it triggers the saved install prompt
+
+#### Scenario: Offline shell loads
+
+- **WHEN** a user is offline and navigates to a previously visited `/app/*` route
+- **THEN** the shell renders from cache and a top banner displays "Du er offline — endringer lagres ikke"
+
+### Requirement: Route protection
+
+All `/app/*` routes SHALL require an authenticated session. Unauthenticated requests SHALL redirect to `/logg-inn` with a `?next=` parameter capturing the intended destination.
+
+#### Scenario: Unauthenticated visit to protected route
+
+- **WHEN** an unauthenticated user visits `/app/vekter`
+- **THEN** the user is redirected to `/logg-inn?next=%2Fapp%2Fvekter`
+
+#### Scenario: Post-login redirect
+
+- **WHEN** a user logs in via `/logg-inn?next=%2Fapp%2Fvekter`
+- **THEN** after authentication they are routed to `/app/vekter`
+
+#### Scenario: Authenticated user keeps access
+
+- **WHEN** an authenticated user visits any `/app/*` route
+- **THEN** the page renders without redirect
+
+### Requirement: Mobile-first responsive layout
+
+All UI components SHALL be designed for mobile (width ≥ 320px) first and SHALL scale to desktop with a single responsive layout (same component tree, Tailwind `md:` breakpoint at 768px). Touch targets SHALL be ≥ 44×44 CSS pixels and no interaction SHALL be hover-dependent.
+
+#### Scenario: Touch target audit
+
+- **WHEN** any interactive element is rendered (button, nav item, chip)
+- **THEN** its rendered hit area is ≥ 44×44 CSS pixels
+
+#### Scenario: No hover-only interaction
+
+- **WHEN** a user with a touchscreen taps any control
+- **THEN** the same outcome occurs as on desktop hover-equivalent
+- **AND** no functionality is gated behind `:hover`
+
+#### Scenario: Desktop layout uses single column with max width
+
+- **WHEN** the viewport is ≥ 768px wide
+- **THEN** the main content area is centered with a `max-width` of approximately 768–960px
+
+### Requirement: Design tokens sourced from Stitch
+
+The application SHALL expose semantic design tokens — color (surface, fg, primary, accent, status colors), spacing scale, type scale — as CSS variables, and Tailwind config SHALL map utility classes to those variables. Token values SHALL be extracted from the Stitch design "Boligscore v2".
+
+#### Scenario: Semantic color tokens exist
+
+- **WHEN** a developer uses the class `bg-surface` or `text-fg`
+- **THEN** the value resolves to a CSS variable that switches between light and dark theme
+
+#### Scenario: Tokens documented
+
+- **WHEN** a contributor reads `docs/design-tokens.md`
+- **THEN** every token is listed with its value in both themes and the Stitch screen it was sourced from
+
+### Requirement: Accessibility floor
+
+The shell SHALL meet WCAG AA contrast in both themes, render visible focus rings on all interactive elements when navigated by keyboard, and never communicate status by color alone (icon + text + color).
+
+#### Scenario: Contrast meets AA
+
+- **WHEN** any text or interactive element is rendered in light or dark theme
+- **THEN** the contrast ratio against its background is ≥ 4.5:1 for body text and ≥ 3:1 for large text and UI components
+
+#### Scenario: Focus ring visible on keyboard navigation
+
+- **WHEN** a user tabs to an interactive element
+- **THEN** the element shows a visible focus indicator (outline or ring) distinguishable from the surrounding UI
+
+#### Scenario: Status uses icon + text not just color
+
+- **WHEN** any status badge is rendered (e.g. property status)
+- **THEN** it includes an icon AND a text label AND a color — never just color

--- a/openspec/changes/navigation-shell/tasks.md
+++ b/openspec/changes/navigation-shell/tasks.md
@@ -1,0 +1,78 @@
+> Conventions: see `openspec/conventions.md`.
+
+## 1. Next.js migration
+
+- [ ] 1.1 Initialize a fresh Next.js 14+ project with App Router, TypeScript, Tailwind, ESLint in a new branch (`v2-shell`).
+- [ ] 1.2 Move v1 source into `/legacy/` for reference; delete `/legacy/` once v2 is shipped.
+- [ ] 1.3 Add `@supabase/supabase-js` and `@supabase/ssr`. Create `lib/supabase/server.ts` (server components, server actions) and `lib/supabase/client.ts` (client components).
+- [ ] 1.4 Configure absolute imports (`@/*` → `./src/*` or root) in `tsconfig.json`.
+- [ ] 1.5 Set up Vercel project (preview deployments per PR).
+
+## 2. Design tokens (extracted from Stitch)
+
+- [ ] 2.1 Pull each Stitch screen via `mcp__stitch__get_screen` and inspect HTML for color/spacing/type values.
+- [ ] 2.2 Define semantic CSS variables in `app/globals.css` under `:root[data-theme="light"]` and `:root[data-theme="dark"]`. Tokens: `--color-bg`, `--color-surface`, `--color-fg`, `--color-fg-muted`, `--color-primary`, `--color-primary-fg`, `--color-accent`, `--color-border`, status colors (`--color-status-favoritt`, `--color-status-vurderer`, etc.), and a spacing scale.
+- [ ] 2.3 Map Tailwind theme to CSS variables in `tailwind.config.ts`: `colors: { surface: 'var(--color-surface)', fg: 'var(--color-fg)', primary: 'var(--color-primary)', ... }`.
+- [ ] 2.4 Type scale: define heading/body/caption sizes following Stitch screens. Use Tailwind `text-*` overrides or CSS variables.
+- [ ] 2.5 Document the full token table in `docs/design-tokens.md` with values in both themes + the Stitch screen the value was sourced from.
+
+## 3. Theme provider
+
+- [ ] 3.1 Inline `<head>` script in `app/layout.tsx` that reads `localStorage.theme` and sets `document.documentElement.dataset.theme` synchronously.
+- [ ] 3.2 `<ThemeProvider>` client component exposes `theme`, `setTheme(t)` via React context. Persists to localStorage and (when authenticated) syncs to user profile.
+- [ ] 3.3 Theme toggle component used in `Meg` page.
+- [ ] 3.4 Verify no-FOUC: e2e test asserts the rendered theme matches `localStorage` on the first paint frame.
+
+## 4. App shell layout
+
+- [ ] 4.1 `app/(public)/layout.tsx` — minimal layout for `/`, `/registrer`, `/logg-inn`, `/invitasjon/[token]`. No bottom nav, no household switcher.
+- [ ] 4.2 `app/app/layout.tsx` — protected app shell. Header (with `<HouseholdSwitcher />` slot from `households` capability) + main + bottom nav. Calls Supabase server-side to verify session; redirects to `/logg-inn?next=...` if absent.
+- [ ] 4.3 `<AppShellHeader>` component: app name on the left, household switcher on the right.
+- [ ] 4.4 `<BottomNav>` component: four destinations (`Boliger` → `/app`, `Vekter` → `/app/vekter`, `Husstand` → `/app/husstand`, `Meg` → `/app/meg`). Active state via `usePathname`.
+- [ ] 4.5 `<main>` gets `pb-[var(--bottom-nav-h)]` (bottom-nav height as a CSS variable) so content scrolls past the fixed nav.
+
+## 5. Property detail tabs
+
+- [ ] 5.1 `app/app/bolig/[id]/layout.tsx` — renders `<PropertyTabs>` (active tab highlighted) and `{children}` slot.
+- [ ] 5.2 Tab destinations: `oversikt`, `min-vurdering`, `sammenligning`, `kommentarer`, `notater`. Each is a route segment with its own `page.tsx`.
+- [ ] 5.3 `app/app/bolig/[id]/page.tsx` — redirects to `./oversikt`.
+- [ ] 5.4 `<PropertyTabs>` component: underline-style, horizontally scrollable on mobile if it overflows, active tab via `usePathname`. Tab labels in Norwegian.
+
+## 6. Public routes
+
+- [ ] 6.1 `app/page.tsx` — landing page (delivered by `auth-onboarding`). Just stub for now.
+- [ ] 6.2 `app/registrer/page.tsx`, `app/logg-inn/page.tsx` — stubs (delivered by `auth-onboarding`).
+- [ ] 6.3 `app/invitasjon/[token]/page.tsx` — stub (delivered by `households`).
+- [ ] 6.4 `app/dev/login/page.tsx` — env-gated test bypass (delivered by `auth-onboarding`).
+
+## 7. PWA setup
+
+- [ ] 7.1 Install `@ducanh2912/next-pwa` and configure in `next.config.mjs`.
+- [ ] 7.2 Create `public/manifest.webmanifest` with `name: "Boligscore"`, `short_name: "Boligscore"`, `icons` (192 + 512), `display: standalone`, `start_url: /app`, `theme_color`, `background_color` (matching design tokens).
+- [ ] 7.3 Add `<link rel="manifest" href="/manifest.webmanifest" />` in `app/layout.tsx`.
+- [ ] 7.4 Generate icons (192px, 512px) from the Stitch logo or a placeholder.
+- [ ] 7.5 Capture `beforeinstallprompt` event in a client component, store in a Zustand/Context store, expose via "Installer som app" button on `Meg` page.
+- [ ] 7.6 Offline banner: top banner that appears when `navigator.onLine === false`, copy "Du er offline — endringer lagres ikke."
+
+## 8. Route protection
+
+- [ ] 8.1 Middleware (`middleware.ts`) that checks Supabase session for `/app/*` paths and redirects to `/logg-inn?next=<encoded path>` if no session.
+- [ ] 8.2 The middleware must NOT block public routes (`/`, `/registrer`, `/logg-inn`, `/invitasjon/[token]`, `/dev/login`).
+- [ ] 8.3 `next` param validation: only allow same-origin paths (no open-redirect via crafted external URL).
+
+## 9. Tests
+
+- [ ] 9.1 **E2E (Playwright)**: navigation across all four bottom-nav destinations works, active state matches URL.
+- [ ] 9.2 **E2E**: property detail page redirects to `/oversikt` by default; switching tabs updates URL; deep link to a tab cold-loads correctly.
+- [ ] 9.3 **E2E**: theme toggle persists across reload; first-paint frame matches stored theme (no FOUC).
+- [ ] 9.4 **E2E**: unauthenticated visit to `/app/vekter` redirects to `/logg-inn?next=%2Fapp%2Fvekter`; after login, lands on `/app/vekter`.
+- [ ] 9.5 **E2E**: PWA installability — Lighthouse PWA audit score ≥ 90 on the staging build.
+- [ ] 9.6 **E2E**: offline banner appears when network is disabled; route still loads from service worker cache.
+- [ ] 9.7 **E2E**: `/dev/login` returns 404 in production build (env guard test).
+- [ ] 9.8 **A11y (axe-core, integrated with Playwright)**: every primary route passes axe with zero serious/critical violations.
+
+## 10. Documentation
+
+- [ ] 10.1 `docs/design-tokens.md` — full token table.
+- [ ] 10.2 Update root `README.md`: how to run the app locally (Next.js + Supabase CLI), where Mailpit lives, how to flip themes for testing.
+- [ ] 10.3 `docs/architecture/shell.md` — short explanation of layout structure, route protection, theme handling.

--- a/openspec/changes/properties/.openspec.yaml
+++ b/openspec/changes/properties/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/properties/README.md
+++ b/openspec/changes/properties/README.md
@@ -1,0 +1,3 @@
+# properties
+
+Property CRUD with status tracking and FINN-import

--- a/openspec/changes/properties/design.md
+++ b/openspec/changes/properties/design.md
@@ -1,0 +1,113 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Context
+
+In v2, every property belongs to a household, not a user. The MVP focuses on **manual entry** with **status workflow** so the household can see where each candidate stands at a glance — FINN-import and image upload are explicitly deferred. The detail page has tabs (`Oversikt | Min vurdering | Sammenligning | Kommentarer | Notater`); this capability owns `Oversikt`, the list view, the empty state, and the property entity itself. Other tabs are owned by `scoring`, `comparison`, and (future) `comments`/`notes` capabilities.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Property entity owned by `household_id`, with status, address, prisinfo, størrelse, basis-fakta.
+- Manual `Ny bolig` form (single page, sectioned).
+- Status as an **extensible lookup table** seeded with the 7 default values.
+- List view (`/app`) with sort, filter, search, status badges.
+- Property detail `Oversikt` tab showing facts + status (auto-redirect from `/app/bolig/[id]` per `navigation-shell`).
+- Empty state with "Legg til første bolig" CTA.
+- `added_by` field surfaced in UI as "Lagt til av X".
+- Cards and badges meet a11y floor (icon + text + color, never just color).
+
+**Non-Goals:**
+- **FINN-import** — separate follow-up change (`properties-finn-import`). The "Fra FINN-lenke" tab on the create form is shown but inactive in MVP; design brief preserved by storing `finn_link` as plain text users can paste.
+- **Image upload / per-property photo gallery** — separate follow-up change (`properties-images`). MVP shows a placeholder thumbnail per property card.
+- **Kommentarer tab** content — placeholder route only; full comments/threading comes later.
+- **Notater tab** content — placeholder route only; private per-user notes (different scope from scoring's section notes).
+- **Property archiving** — soft-delete with archive view. MVP supports hard delete with typed-name confirmation (smaller-blast-radius variant: typed `bolig` keyword, since "type the address" is too long).
+
+## Decisions
+
+### D1. Status as a lookup table, not a database enum
+
+**Choice**: `property_statuses` table with `(id, household_id NULLABLE, label, color, icon, is_terminal, sort_order)`. `household_id NULL` = global / built-in status; non-null = household-specific override or addition. Seeded with the 7 default values as global rows.
+
+**Alternative considered**: Postgres `ENUM` type.
+
+**Rationale**: extensibility is a stated requirement. Adding a new status to a Postgres enum requires `ALTER TYPE ... ADD VALUE`, which can't run inside a transaction in older versions and is annoying. A lookup table is more flexible and lets households add custom statuses later without schema changes. Cost: an extra join on every property read — negligible at this scale.
+
+### D2. Address is a single freeform string
+
+**Choice**: `properties.address TEXT NOT NULL`.
+
+**Alternative considered**: structured fields (street, number, postal code, city).
+
+**Rationale**: Norwegian addresses have edge cases (rural addresses, gnr/bnr, hytte at "Veien til hytta"). A freeform field handles all of them. We can add structured parsing if/when FINN-import lands. For now, search is text-based against the freeform field, which works fine for the household's small list.
+
+### D3. List view uses a single SQL view for derived totals
+
+**Choice**: create a Postgres view `property_list_view` joining `properties` with computed `felles_total`, `din_total`, the partner's score (if any), and the active user's score count. The list query selects from this view filtered by `household_id` and the active user.
+
+**Alternative considered**: compute totals client-side after fetching scores.
+
+**Rationale**: list view sorts by `Felles total` by default — sorting on a derived value requires either client-side sort on a fully-loaded dataset (fine for a household's small list, but messy for pagination later) or a server-side computed column. The view is clean SQL, gets indexed nicely, and survives the move to pagination.
+
+### D4. Default sort with `NULLS LAST`
+
+**Choice**: list default sort is `felles_total DESC NULLS LAST`. Properties without a felles total (no scoring done yet) appear at the bottom.
+
+**Rationale**: a property with no scores isn't ranked; pushing them to the bottom matches the user's mental model of "things I've evaluated".
+
+### D5. Filter UI: bottom sheet on mobile, popover on desktop
+
+**Choice**: same component, different presentation via Tailwind responsive classes. Mobile: full-width sheet sliding up from bottom. Desktop: popover anchored to the filter button.
+
+**Rationale**: brief explicitly says "Filter-panel (bottom sheet på mobil, popover på desktop)". Use Headless UI's `Dialog` component primitive — it supports both presentations with the same accessibility behavior (focus trap, escape to close).
+
+### D6. `added_by` field, surfaced in UI
+
+**Choice**: `properties.added_by uuid REFERENCES auth.users(id)`. Display as "Lagt til av Ine" on the property card and Oversikt tab.
+
+**Rationale**: small attribution helps the household remember who scouted what (especially when one partner does most of the FINN-scrolling).
+
+### D7. Year built validation
+
+**Choice**: `year_built INT CHECK (year_built BETWEEN 1800 AND extract(year FROM now())::int + 5)`.
+
+**Rationale**: most Norwegian housing is from after 1800; +5 years allows for under-construction listings. Catches obvious typos like `2030` for a `2003` property.
+
+### D8. Default status = `vurderer`
+
+**Choice**: when a property is created without an explicit status, default is `vurderer`.
+
+**Rationale**: matches the brief's framing — adding a property means you're considering it. `favoritt` is something you upgrade to deliberately.
+
+### D9. Hard delete with confirmation, not soft archive
+
+**Choice**: deleting a property removes the row and cascades to scores, felles-scores, notes for that property. UI requires typing `slett` (or a similar keyword) to confirm.
+
+**Alternative considered**: soft delete with `archived_at`.
+
+**Rationale**: same reasoning as households deletion (D11 there). Simpler schema. Typed-keyword modal makes accidents implausible. Future "archived list" is easy to add later via `archived_at` if users ask for undo.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| `property_statuses` global rows accidentally edited by RLS bypass | Global rows have `household_id IS NULL`; RLS denies updates/deletes when `household_id IS NULL` regardless of caller. |
+| Sort by `felles_total` is expensive without scoring data | View pre-computes, indexed on `(household_id, felles_total DESC NULLS LAST)`. At scale beyond this — cache. |
+| User adds a custom status, then deletes it while properties reference it | `property_statuses` referenced via `RESTRICT` — cannot delete a status with referencing rows. UI surfaces this as "Du må flytte boligene til en annen status før du sletter denne." |
+| Address freeform → search misses on misspellings | Use `ILIKE` for case-insensitive substring search. Add Postgres trigram index later if needed. |
+| Year built CHECK breaks if app runs past 2030 without re-evaluation | The CHECK is `extract(year FROM now())::int + 5` — dynamic, recomputed on each insert, no maintenance. |
+| `added_by` user is later removed from household | Membership change doesn't break the FK (FK is to `auth.users`, not `household_members`). UI handles missing-member case as "Lagt til av tidligere medlem". |
+
+## Resolved Decisions
+
+### D10. The "Fra FINN-lenke" tab is hidden in MVP
+
+**Choice**: design brief implies a two-tab create form, but in MVP we render only the Manual tab. The `Fra FINN-lenke` tab is implemented as a stub that returns "Kommer snart — bruk manuell registrering for nå." or simply hidden behind a feature flag. Going with **hidden** — fewer dead UIs.
+
+**Rationale**: a stub tab clutters the UI and invites support questions. Add it back when the FINN-import follow-up ships.
+
+### D11. Empty `Kommentarer` and `Notater` tabs render placeholders
+
+**Choice**: these tabs render a "Kommer snart" empty-state component in MVP. They are NOT removed from the tab strip — the design brief locks the five-tab structure and we don't want to break it now and add tabs later.
+
+**Rationale**: stable UX during the v2 rollout. Users see what's coming.

--- a/openspec/changes/properties/proposal.md
+++ b/openspec/changes/properties/proposal.md
@@ -1,0 +1,48 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Why
+
+In v1, adding a property means filling out a manual form. v2 keeps the manual form for MVP and adds **status workflow** (favoritt → vurderer → på visning → i budrunde → bud inne → kjøpt / ikke aktuell) so the household can see where each candidate stands at a glance. Properties must be owned by the household, not a user, so partners share the same list. **FINN-import and image upload are deferred** to later phases — manual entry is the MVP path.
+
+## What Changes
+
+- Property records owned by `household_id` (depends on `households` capability).
+- **Manual entry form** (only path in MVP), grouped in sections per the design brief:
+  - Adresse & FINN-lenke (URL field stored as plain text; no parsing in MVP).
+  - Prisinfo (totalpris, omkostninger, felleskostnader).
+  - Størrelse (BRA, primærrom, soverom, bad).
+  - Basis-fakta (byggeår, boligtype, etasje).
+  - Status (dropdown — see below).
+- **Status as an extensible lookup table** (`property_statuses`), not a hard DB enum. Seeded with the 7 default values from the brief but new statuses can be added per-household or globally without a schema migration.
+  - Default seeds: `favoritt`, `vurderer`, `på visning`, `i budrunde`, `bud inne`, `kjøpt`, `ikke aktuell`.
+  - Each status has: id, label, color, icon, is_terminal (true for `kjøpt`/`ikke aktuell`), sort_order.
+- Status badge shown on every property card. Always **icon + text + color** (color-only is an a11y violation per the brief).
+- `added_by` field (FK to `auth.users`) — which household member added the property, shown subtly on the card/detail (e.g. "Lagt til av Ine").
+- List view (forsiden):
+  - Sorting: `Felles total` (default) | `Pris` | `Nyeste først` | `Din score`.
+  - Filter sheet: status, prisspenn, BRA-spenn, område (text).
+  - Search field (adresse, kommentar, notat).
+- Card layout: address, `Pris • BRA • byggeår`, `Felles: 78 • Din: 76`, status-badge, "lagt til av X". (No image in MVP — placeholder illustration.)
+- Detail view structured as tabs: `Oversikt` (this capability) | `Min vurdering` (scoring) | `Sammenligning` (comparison) | `Kommentarer` | `Notater`.
+- Empty state: illustration + "Ingen boliger ennå" + CTA `+ Legg til bolig`.
+
+## Out of MVP scope (future changes)
+
+- **FINN-import**: paste FINN URL → server-side parse → prefill form. Requires Next.js API route or Supabase Edge Function. Will be a separate `properties-finn-import` change later.
+- **Image upload**: per-property photo gallery via Supabase Storage. Will be a separate `properties-images` change. MVP shows a placeholder thumbnail.
+- **Property comments thread** (`Kommentarer` tab content): tab placeholder in MVP, full comments capability later.
+
+## Capabilities
+
+### New Capabilities
+- `properties`: property entity, manual entry, extensible status workflow, list view (sort/filter/search), detail Oversikt tab, empty state.
+
+### Modified Capabilities
+<!-- None - this is greenfield. -->
+
+## Impact
+
+- **Database**: `properties(id, household_id, address, finn_link, status_id, price, costs, monthly_costs, bra, primary_rooms, bedrooms, bathrooms, year_built, property_type, floor, added_by, created_at, updated_at)`. New `property_statuses(id, household_id NULL for global, label, color, icon, is_terminal, sort_order)`. Index on `(household_id, status_id)` for list queries.
+- **UI**: replace v1 modal-based form with full-page `Ny bolig` flow. New `PropertyCard` design with status badge. New filter bottom sheet.
+- **Routes**: `/app` (list), `/app/bolig/ny`, `/app/bolig/[id]` (with tab subroutes).
+- **Dependencies**: requires `households`. Blocks `scoring`, `comparison`.

--- a/openspec/changes/properties/specs/properties/spec.md
+++ b/openspec/changes/properties/specs/properties/spec.md
@@ -1,0 +1,213 @@
+## ADDED Requirements
+
+### Requirement: Property creation
+
+The system SHALL allow an `owner` or `member` of a household to create a property with a non-empty address. Other fields SHALL be optional. The creator's user id SHALL be recorded in `added_by`. Default status SHALL be `vurderer`.
+
+#### Scenario: Successful manual creation
+
+- **WHEN** an `owner` or `member` submits a `Ny bolig` form with address `"Storgata 1, 0182 Oslo"` and no status selected
+- **THEN** a `properties` row is inserted with `household_id` (active household), `address`, `status_id = vurderer`, `added_by = caller`, `created_at = now()`
+
+#### Scenario: Empty address rejected
+
+- **WHEN** the form is submitted with an empty or whitespace-only address
+- **THEN** an inline validation error displays and no row is inserted
+
+#### Scenario: Viewer cannot create
+
+- **WHEN** a `viewer` attempts to create a property (via UI or direct API)
+- **THEN** RLS denies the insert and the UI shows "Du har ikke tilgang til å legge til boliger"
+
+#### Scenario: Year built out of range rejected
+
+- **WHEN** `year_built` is set to `1500` or `next year + 6`
+- **THEN** the database CHECK constraint rejects the insert
+
+### Requirement: Property update
+
+The system SHALL allow `owner` and `member` roles to update any field of a property in their household. The `household_id`, `added_by`, and `created_at` fields SHALL be immutable.
+
+#### Scenario: Member updates property fields
+
+- **WHEN** a `member` updates the `price` and `status_id` of a property in their household
+- **THEN** the update succeeds
+
+#### Scenario: Viewer cannot update
+
+- **WHEN** a `viewer` attempts to update a property
+- **THEN** RLS denies the operation
+
+#### Scenario: Immutable fields cannot be changed
+
+- **WHEN** any user attempts to update `household_id`, `added_by`, or `created_at`
+- **THEN** the operation is denied (RLS or trigger)
+
+### Requirement: Property deletion
+
+The system SHALL allow `owner` and `member` roles to delete a property after typed-keyword confirmation. Deletion SHALL cascade to all dependent rows (scores, felles-scores, notes) for that property.
+
+#### Scenario: Successful deletion
+
+- **WHEN** an `owner` or `member` deletes a property after typing the confirmation keyword
+- **THEN** the `properties` row and all dependent rows are removed via FK cascade
+
+#### Scenario: Viewer cannot delete
+
+- **WHEN** a `viewer` attempts to delete a property
+- **THEN** RLS denies the operation
+
+### Requirement: Status workflow
+
+The system SHALL maintain an extensible `property_statuses` lookup table seeded with seven defaults: `favoritt`, `vurderer`, `på visning`, `i budrunde`, `bud inne`, `kjøpt`, `ikke aktuell`. Households MAY add custom statuses. Global (built-in) statuses SHALL NOT be deletable or modifiable.
+
+#### Scenario: Default statuses available
+
+- **WHEN** a new household is created
+- **THEN** all seven default statuses are immediately usable when creating a property (they are global rows visible to every household)
+
+#### Scenario: Household adds custom status
+
+- **WHEN** an `owner` adds a status `"Reservert"` for their household
+- **THEN** the new status is available for properties in that household only
+
+#### Scenario: Global status cannot be deleted
+
+- **WHEN** any user attempts to delete a global status (one with `household_id IS NULL`)
+- **THEN** RLS or a trigger denies the operation
+
+#### Scenario: Status with references cannot be deleted
+
+- **WHEN** a user tries to delete a custom status that is referenced by at least one property
+- **THEN** the database FK with `ON DELETE RESTRICT` blocks the deletion
+- **AND** the UI displays "Du må flytte boligene til en annen status før du sletter denne"
+
+### Requirement: Property listing
+
+The system SHALL display all properties in the active household on `/app`, with default sort by `felles_total DESC NULLS LAST`. Each card SHALL display: address, price summary, BRA, year built, status badge (icon + text + color), `added_by` attribution, the user's own total, and the felles total.
+
+#### Scenario: Default list view
+
+- **WHEN** an authenticated user with an active household visits `/app`
+- **THEN** the list renders properties in the active household
+- **AND** sorted by `felles_total DESC NULLS LAST`
+
+#### Scenario: Card content
+
+- **WHEN** the list renders a property
+- **THEN** the card includes address, price/BRA/byggeår summary, status badge, "Lagt til av X", `Felles: 78 • Din: 76` (or `— ` if no scores yet)
+
+#### Scenario: Other-household properties not visible
+
+- **WHEN** a user has multiple households and the active household is A
+- **THEN** properties belonging to household B are NOT in the list
+
+### Requirement: Property sorting
+
+The system SHALL allow sorting the property list by: `Felles total`, `Pris`, `Nyeste først` (created_at desc), `Din score`. The selected sort SHALL persist for the user (per active household) across sessions.
+
+#### Scenario: Sort by price
+
+- **WHEN** the user selects sort `Pris`
+- **THEN** the list re-renders sorted by `price ASC NULLS LAST`
+
+#### Scenario: Sort persists
+
+- **WHEN** the user picks a non-default sort and reloads or returns later
+- **THEN** the previously selected sort is applied (stored in `localStorage` keyed by `household_id`)
+
+### Requirement: Property filtering
+
+The system SHALL allow filtering by: status (multi-select), price range, BRA range, and område (text match against address). The filter UI SHALL render as a bottom sheet on mobile and a popover on desktop. Active filters SHALL be visible as removable chips above the list.
+
+#### Scenario: Filter by status
+
+- **WHEN** the user selects only `på visning` and `i budrunde` statuses
+- **THEN** only properties with those statuses appear in the list
+
+#### Scenario: Filter by price range
+
+- **WHEN** the user sets price range to 4M-6M NOK
+- **THEN** only properties with `price BETWEEN 4_000_000 AND 6_000_000` appear
+
+#### Scenario: Filter chips
+
+- **WHEN** any filter is active
+- **THEN** an "active filter" chip appears above the list for each filter, each with a remove button
+
+#### Scenario: Clear all filters
+
+- **WHEN** the user clicks `Fjern filtre`
+- **THEN** all filters are cleared and the full list re-renders
+
+### Requirement: Property search
+
+The system SHALL provide a text search field above the list that matches against `address` (case-insensitive substring). Search SHALL combine with active filters (intersection).
+
+#### Scenario: Search match
+
+- **WHEN** the user types `storgata` in the search field
+- **THEN** the list shows only properties whose address contains `storgata` (case-insensitive)
+
+#### Scenario: Search debounced
+
+- **WHEN** the user is typing rapidly
+- **THEN** the query fires after a brief debounce (~250ms idle), not on every keystroke
+
+#### Scenario: No results
+
+- **WHEN** the search yields zero matches
+- **THEN** an empty-search state displays "Ingen boliger matcher søket" with a `Fjern søk` button
+
+### Requirement: Property detail Oversikt tab
+
+The system SHALL render the `Oversikt` tab at `/app/bolig/[id]/oversikt` showing: address, status (with badge + change action), price/BRA/year built/property type/floor/bedrooms/bathrooms, FINN-link (clickable, external), `added_by` attribution, created/updated timestamps.
+
+#### Scenario: Oversikt content
+
+- **WHEN** a user visits the Oversikt tab for a property
+- **THEN** all fields above are rendered (with `—` placeholder for unset optional fields)
+
+#### Scenario: Status change inline
+
+- **WHEN** a user with role `owner` or `member` taps the status badge
+- **THEN** a status picker opens with all available statuses (global + this household's custom)
+- **AND** selecting a new status updates the property and the badge re-renders
+
+#### Scenario: Viewer cannot change status
+
+- **WHEN** a `viewer` taps the status badge
+- **THEN** the picker does not open (or opens read-only)
+
+### Requirement: Empty state
+
+The system SHALL show an empty state on `/app` when the active household has zero properties. The empty state SHALL include an illustration, the heading "Ingen boliger ennå", supporting text, and a primary CTA `+ Legg til bolig`.
+
+#### Scenario: Zero properties
+
+- **WHEN** a user with an active household containing no properties visits `/app`
+- **THEN** the empty state renders instead of an empty list
+
+#### Scenario: Filtered to zero
+
+- **WHEN** the household has properties but the active filters/search match none
+- **THEN** a different state renders ("Ingen boliger matcher filtrene") with a `Fjern filtre` action — this is distinct from the "no properties" empty state
+
+### Requirement: Floating action button
+
+The system SHALL render a floating action button on `/app` for `+ Ny bolig` that is reachable with one thumb on mobile (anchored above the bottom nav, lower-right corner).
+
+#### Scenario: FAB visible on list
+
+- **WHEN** an `owner` or `member` views `/app`
+- **THEN** the FAB is rendered
+
+#### Scenario: FAB hidden for viewer
+
+- **WHEN** a `viewer` views `/app`
+- **THEN** the FAB is hidden (consistent with role permissions)
+
+#### Scenario: FAB navigates to create
+
+- **WHEN** the FAB is tapped
+- **THEN** the user is routed to `/app/bolig/ny`

--- a/openspec/changes/properties/tasks.md
+++ b/openspec/changes/properties/tasks.md
@@ -1,0 +1,99 @@
+> Conventions: see `openspec/conventions.md`.
+
+## 1. Database schema
+
+- [ ] 1.1 Migration: create `property_statuses(id uuid PK default gen_random_uuid(), household_id uuid REFERENCES households(id) ON DELETE CASCADE, label text NOT NULL, color text NOT NULL, icon text NOT NULL, is_terminal bool NOT NULL default false, sort_order int NOT NULL default 0, created_at timestamptz NOT NULL default now())`. Unique on `(household_id, label)`.
+- [ ] 1.2 Seed seven global statuses: `favoritt`, `vurderer`, `på visning`, `i budrunde`, `bud inne`, `kjøpt` (is_terminal=true), `ikke aktuell` (is_terminal=true). All with `household_id = NULL`.
+- [ ] 1.3 Migration: create `properties(id uuid PK default gen_random_uuid(), household_id uuid NOT NULL REFERENCES households(id) ON DELETE CASCADE, address text NOT NULL CHECK (length(trim(address)) > 0), finn_link text, price bigint, costs bigint, monthly_costs bigint, bra numeric, primary_rooms int, bedrooms int, bathrooms numeric, year_built int CHECK (year_built BETWEEN 1800 AND extract(year FROM now())::int + 5), property_type text, floor text, status_id uuid NOT NULL REFERENCES property_statuses(id) ON DELETE RESTRICT, added_by uuid NOT NULL REFERENCES auth.users(id), created_at timestamptz NOT NULL default now(), updated_at timestamptz NOT NULL default now())`.
+- [ ] 1.4 Trigger: prevent updates to `household_id`, `added_by`, `created_at`.
+- [ ] 1.5 Trigger: update `updated_at = now()` on every update.
+- [ ] 1.6 Indexes: `(household_id, status_id)`, `(household_id, created_at DESC)`, GIN trigram on `address` for search (optional, ILIKE works for MVP).
+
+## 2. RLS policies
+
+- [ ] 2.1 Enable RLS on `properties` and `property_statuses`.
+- [ ] 2.2 `properties` SELECT: `EXISTS member of household_id`.
+- [ ] 2.3 `properties` INSERT/UPDATE/DELETE: `has_household_role(household_id, ARRAY['owner','member'])`.
+- [ ] 2.4 `property_statuses` SELECT: row is global (`household_id IS NULL`) OR caller is member of `household_id`.
+- [ ] 2.5 `property_statuses` INSERT: `has_household_role(NEW.household_id, ARRAY['owner','member'])` AND `NEW.household_id IS NOT NULL` (members can never write a global status).
+- [ ] 2.6 `property_statuses` UPDATE/DELETE: `has_household_role(household_id, ARRAY['owner','member'])` AND `household_id IS NOT NULL`. Global rows immutable.
+
+## 3. SQL view for list
+
+- [ ] 3.1 Create view `property_list_view` joining `properties`, computed `felles_total` (from `property_felles_scores` × `household_weights`), and parameterized `din_total` and `partner_total` (the latter two implemented as a SQL function `get_property_list(active_household uuid, active_user uuid)` returning a set of rows, since views can't take parameters).
+- [ ] 3.2 Function pre-computes:
+  - `felles_total` (Σ score × weight / Σ weight × 10 across criteria with felles score)
+  - `your_total` (using user's personal weights)
+  - `partner_id` and `partner_total` (if exactly one other member; otherwise null)
+  - `your_score_count` (how many of 22 criteria you've scored — for "X av 22" UI)
+  - All `properties.*` columns + status label/color/icon
+
+## 4. Server actions / data layer
+
+- [ ] 4.1 `createProperty(input)` — validates, inserts.
+- [ ] 4.2 `updateProperty(id, patch)` — checks role via RLS.
+- [ ] 4.3 `deleteProperty(id)` — owner/member only, requires confirmation keyword on client.
+- [ ] 4.4 `listProperties({ householdId, sort, filters, search })` — calls the function from 3.1, applies client-friendly filters/search server-side.
+- [ ] 4.5 `getProperty(id)` — single property + joined status.
+- [ ] 4.6 `listStatuses(householdId)` — global + household custom.
+- [ ] 4.7 `createStatus({ householdId, label, color, icon, sort_order })` — household-scoped only.
+- [ ] 4.8 `setPropertyStatus(propertyId, statusId)` — convenience wrapper for the inline status picker.
+
+## 5. UI — Ny bolig form (`/app/bolig/ny`)
+
+- [ ] 5.1 Single-page form, sectioned per the design brief: Adresse & FINN-lenke / Prisinfo / Størrelse / Basis-fakta / Status.
+- [ ] 5.2 The "Fra FINN-lenke" tab from the brief is **hidden in MVP** (D10). Manual is the only path.
+- [ ] 5.3 Status field is a select populated by `listStatuses(activeHouseholdId)`. Default selection: `vurderer`.
+- [ ] 5.4 On submit: `createProperty(...)` → redirect to `/app/bolig/[id]/oversikt`.
+- [ ] 5.5 Validation: address required and non-empty; numeric fields parse correctly; year_built within range.
+- [ ] 5.6 Cancel button → `/app`.
+- [ ] 5.7 Form fields are touch-friendly (≥ 44px tap targets).
+
+## 6. UI — List page (`/app`)
+
+- [ ] 6.1 Search input above list (debounced 250ms).
+- [ ] 6.2 Sort dropdown: Felles total / Pris / Nyeste først / Din score. Persists in localStorage keyed by `household_id`.
+- [ ] 6.3 Filter button → opens bottom sheet (mobile) / popover (desktop). Filters: status (multi), price range, BRA range, område.
+- [ ] 6.4 Active-filter chips row above list, each with remove button.
+- [ ] 6.5 Property cards rendered in a single-column scrollable list (mobile-first).
+- [ ] 6.6 Empty state when household has zero properties.
+- [ ] 6.7 No-results state when filters/search yield zero (different from empty state).
+- [ ] 6.8 FAB `+ Ny bolig` (visible to owner/member, hidden for viewer).
+
+## 7. UI — Property card
+
+- [ ] 7.1 `<PropertyCard>` component: address, price summary (`5 200 000 kr`), BRA + year built, status badge, "Lagt til av X" subtle label, `Felles: 78 • Din: 76` (or `— ikke scoret` placeholder when no scores).
+- [ ] 7.2 Status badge: pill with icon + text + color (token-driven). Always include all three per a11y rule.
+- [ ] 7.3 Card click → `/app/bolig/[id]` (which redirects to `/oversikt`).
+- [ ] 7.4 Long-press / context menu (mobile) — defer to later; tap-only in MVP.
+
+## 8. UI — Oversikt tab (`/app/bolig/[id]/oversikt`)
+
+- [ ] 8.1 Display all property fields with `—` placeholders for unset.
+- [ ] 8.2 Status badge tappable for owner/member; opens picker; updates inline.
+- [ ] 8.3 "Lagt til av X" with link to that user's profile or just the name.
+- [ ] 8.4 FINN-link displays as clickable external link with opens-in-new-tab.
+- [ ] 8.5 "Slett bolig" action in a danger zone footer (typed-keyword confirmation modal).
+
+## 9. UI — Status badge component
+
+- [ ] 9.1 `<StatusBadge status={...} />` — pill with icon + text. Color from token (status color comes from the lookup row).
+- [ ] 9.2 Variants: `inline` (text + icon, badge style), `interactive` (clickable, opens picker).
+- [ ] 9.3 Used on cards and Oversikt tab.
+
+## 10. Tests
+
+- [ ] 10.1 **Unit (Vitest)**: address validator; year_built range checker (note: relies on current year, mock `Date.now()`).
+- [ ] 10.2 **Integration**: RLS — viewer cannot insert/update/delete; member cross-household access denied; global status mutation blocked.
+- [ ] 10.3 **Integration**: `property_list_view`/list function returns correct totals and partner data for various member counts (1, 2, 3+).
+- [ ] 10.4 **Integration**: deleting a property cascades to scores/felles/notes; deleting a status that's in use is blocked.
+- [ ] 10.5 **E2E (Playwright)**: add property → see in list with `vurderer` badge → change status to `på visning` → reload, status persists.
+- [ ] 10.6 **E2E**: filter by status → only matching properties shown; clear filter → full list back.
+- [ ] 10.7 **E2E**: search by partial address → debounced, returns matches; no-match shows empty-search state.
+- [ ] 10.8 **E2E**: viewer's `/app` shows no FAB and direct visit to `/app/bolig/ny` redirects or shows access-denied.
+- [ ] 10.9 **E2E**: empty state renders for new household; "Legg til første bolig" CTA navigates to `/app/bolig/ny`.
+
+## 11. Documentation
+
+- [ ] 11.1 `docs/architecture/properties.md` — schema, RLS, list function, status lookup pattern.
+- [ ] 11.2 Update `README.md` brief: how to seed test properties via `supabase/seed.sql`.

--- a/openspec/changes/scoring/.openspec.yaml
+++ b/openspec/changes/scoring/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/scoring/README.md
+++ b/openspec/changes/scoring/README.md
@@ -1,0 +1,3 @@
+# scoring
+
+Per-user scoring of 22 criteria with autosave

--- a/openspec/changes/scoring/design.md
+++ b/openspec/changes/scoring/design.md
@@ -1,0 +1,103 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Context
+
+Scoring is the **act** the product is built around — the user opens a property, taps through 22 chip-rad sliders to record their gut feeling, and walks away with a structured opinion they can later compare with their partner. v1 stored a single set of scores per property; v2 stores `(property × user × criterion)` so each member's vurdering is independent and private until they hit the `Sammenligning` tab. Scoring needs to feel **fast and forgiving** on mobile: chip taps, autosave, no commit step, ability to revise indefinitely, and a counter that says "X av 22 scoret" so users know where they stand.
+
+## Goals / Non-Goals
+
+**Goals:**
+- 22-criteria scoring per user × property, persisted in `property_scores`.
+- `Min vurdering` tab at `/app/bolig/[id]/min-vurdering` with chip-rad UI.
+- Autosave on chip tap; no commit / submit step.
+- Counter showing scored / total.
+- Section notes (one short textarea per section) — `private` by default, schema supports `shared` value for future change.
+- Change log captured for every score insert/update via DB trigger (history UI is out of MVP scope).
+- Fakta section auto-derived (pris/kvm, størrelse, alder) — read-only display.
+
+**Non-Goals:**
+- **Locking / "I'm done scoring" state** — explicitly rejected; scores remain editable.
+- **Historikk view** — UI to browse score history. Data captured from day 1 but no UI in MVP.
+- **Shared section notes** — schema supports it (`visibility = 'shared'`), no UI toggle in MVP.
+- **Per-criterion comments** — different from section notes; if needed, future change.
+- **Score revisions tied to property edits** — if a property's address changes, scores stay; we don't snapshot.
+
+## Decisions
+
+### D1. Score table keyed on (property × user × criterion)
+
+**Choice**: `property_scores(property_id, user_id, criterion_id, score INT 0..10, updated_at)`. Composite primary key.
+
+**Rationale**: every score is uniquely identified by who scored which criterion on which property. Upserts on score change are simple `INSERT ... ON CONFLICT (property_id, user_id, criterion_id) DO UPDATE`.
+
+### D2. History captured by trigger, not application code
+
+**Choice**: `property_score_history(id, property_id, user_id, criterion_id, old_score, new_score, changed_at)` populated by `AFTER INSERT OR UPDATE` trigger on `property_scores`.
+
+**Alternative considered**: write history rows from server actions.
+
+**Rationale**: triggers are atomic with the score change and impossible to skip. Server-side history writes can be bypassed by direct DB writes (data import scripts, future bulk operations) and would be silently incomplete. Triggers are bullet-proof.
+
+### D3. Autosave on chip select
+
+**Choice**: when the user taps a chip, fire the upsert immediately (no debounce). Optimistic UI: chip fills before the round-trip completes; if the request fails, revert + show inline error.
+
+**Alternative considered**: debounce 500ms (saves on rapid retap).
+
+**Rationale**: rapid retaps are rare — a user tapping 7 then realizing they meant 8 is two events, not 50. The debounce was a v1 carryover assumption. Optimistic UI hides round-trip latency and the round-trip cost is small (single row upsert).
+
+### D4. Section notes: `visibility` field with `'private'` default
+
+**Choice**: `property_section_notes(property_id, user_id, section_id, body, visibility, updated_at)` with `visibility CHECK IN ('private','shared') NOT NULL DEFAULT 'private'`. Composite key `(property_id, user_id, section_id)`.
+
+**Rationale**: future-ready without UI changes today. RLS on the SELECT side reads `(visibility = 'shared') OR (user_id = auth.uid())`. Today every read returns only your own; tomorrow the same RLS lets shared notes through.
+
+### D5. Counter computed in the SQL function, not client-side
+
+**Choice**: the property list function (`get_property_list` from `properties` capability) and a single-property function (`get_property_with_scores`) include `your_score_count` (int 0–22). The client renders the counter from this value.
+
+**Rationale**: avoids fetching all 22 score rows just to count them. The function is the single source of truth used by both the list cards and the `Min vurdering` tab counter.
+
+### D6. Fakta section is presentational only
+
+**Choice**: `Fakta` (pris/kvm, størrelse, alder) is rendered above or below the scored sections with read-only values. No `criterion` rows, no scoring possible.
+
+**Rationale**: the brief explicitly says "auto-beregnet, read-only". Treating these as scored criteria would inflate the criterion count and pollute the math.
+
+### D7. Optimistic UI with fail-on-conflict
+
+**Choice**: client renders the new chip state instantly; rolls back if the server returns an error. Errors include a short Norwegian toast: "Kunne ikke lagre — prøv igjen".
+
+**Rationale**: optimistic UI is what makes the chip-rad feel snappy. The simple rollback covers transient failures; users can re-tap.
+
+### D8. Section notes textarea autosave with debounce
+
+**Choice**: notes textarea autosaves on `blur` and on a 1-second idle debounce while typing. Indicator shows "lagrer..." → "lagret" on completion.
+
+**Rationale**: notes are typed text, not chip taps. Saving on every keystroke is wasteful; saving only on blur risks losing data on accidental nav. Debounced save + blur = good middle ground.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Trigger writes history row even when score is unchanged (e.g. user taps the same chip twice) | Trigger condition: `WHEN (OLD.score IS DISTINCT FROM NEW.score)`. No-op updates produce no history entry. |
+| Optimistic UI shows wrong state if server denies | Client awaits the server response; on failure, rolls back to previous score and shows toast. Non-blocking — user can retry. |
+| Counter is stale if scores change in another tab | Counter is fetched on `Min vurdering` mount and after each save (since save returns the updated count). Tab-focus refresh handles cross-tab drift. |
+| User adds a criterion via DB tinkering → counter goes above 22 | `criteria` is read-only in MVP (RLS denies non-service-role writes). Counter shows actual count vs `criteria.count`. |
+| Section notes visibility = 'shared' set incorrectly via DB | RLS only allows the user themselves to UPDATE the row, so visibility can't be changed by partner. Future UI flip is the correct path. |
+| Score history grows unbounded | Acceptable in MVP. Add monthly partitioning or pruning later if it becomes a problem (it won't at single-household scale). |
+| User scoring on flaky network → optimistic shows score, server save fails, user thinks it saved | Toast is visible; chip rolls back. If they don't notice, the next pageview will show the absent score. Worth a "show inline indicator if any score has unsynced state" upgrade if it becomes a real problem. |
+
+## Resolved Decisions
+
+### D9. Section notes are one per section, not one per criterion
+
+**Choice**: textarea attaches to a section (e.g. `Bolig innvendig`), not to each criterion. Brief calls these "huskelapp" — quick reminders. One per section is enough granularity.
+
+**Rationale**: per-criterion notes would be 22 textareas which is too many. One per section keeps the UI simple.
+
+### D10. Fakta values are computed on the fly, not stored
+
+**Choice**: `pris/kvm` = `price / bra` (handle null bra), `størrelse` = `bra`, `alder` = `current_year - year_built` (handle null year). All computed in the SQL function or client-side.
+
+**Rationale**: storing derived data is a footgun — it can drift from its source. Compute on read; cheap.

--- a/openspec/changes/scoring/proposal.md
+++ b/openspec/changes/scoring/proposal.md
@@ -1,0 +1,44 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Why
+
+The whole point of v2 is **independent partner scoring** — Ine and Kanta each score the same property without seeing each other's numbers, then reconcile in `comparison`. v1 stores a single set of scores per property, which makes that flow impossible. Scoring needs to be re-modeled as `(property_id, user_id, criterion) → score` so each member's vurdering is private and standalone, and the UI needs to be a touch-friendly chip-rad on mobile that autosaves as the user taps. Every change to a score is **logged** so the household can see how a vurdering evolved over time.
+
+## What Changes
+
+- **BREAKING**: Scores live in a `property_scores` table keyed by `(property_id, user_id, criterion_id)`. Not a column on `properties`.
+- 22 scoring criteria, grouped in three sections (matching the design brief):
+  - **Bolig innvendig**: kjøkken, bad, planløsning, lys/luftighet, oppbevaring, stue, balkong/terrasse.
+  - **Beliggenhet & område**: områdeinntrykk, nabolagsfølelse, offentlig transport, skoler/barnehager.
+  - **Helhet**: inntrykk på visning, potensial.
+  - **Fakta** (auto-derived, not scored): pris/kvm, størrelse, alder.
+- UI per criterion: label + short description + **chip-rad 0–10** (11 chips). Selected chip filled in primary color. Touch target ≥ 44×44px.
+- **Autosave** on tap with subtle "lagret" indicator. No save button. Debounce timing is an implementation detail — pick something reasonable.
+- Counter at top of `Min vurdering` tab: `13 av 22 kriterier scoret`. Unscored rows render greyed out with `— (ikke scoret)`.
+- **No locking** — scores remain editable any time. Either partner can revise their own scores after seeing the comparison.
+- **Change log**: every score insert/update is recorded in `property_score_history(id, property_id, user_id, criterion_id, old_score, new_score, changed_at)`. Used later for a "Historikk" view (UI for the log is **out of MVP scope** — only the data is captured from day 1).
+- **Section notes**: "huskelapp" textarea per section. Default `visibility = 'private'` (only the author sees it). Schema includes a `visibility` field with future values (`'shared'`) so we can flip notes to partner-visible later without a migration.
+
+## Capabilities
+
+### New Capabilities
+- `scoring`: 22-criteria scoring per user, autosave, counter, section notes (private in MVP, shareable in schema), change log capture, `Min vurdering` tab UI.
+
+### Modified Capabilities
+<!-- None - replaces v1's score column with a per-user score table. -->
+
+## Out of MVP scope (future)
+
+- **Historikk view**: UI to browse score change history. Data captured from day 1, view added later.
+- **Shared section notes**: data model supports it (`visibility = 'shared'`), but UI toggle and display added later.
+
+## Impact
+
+- **Database**:
+  - `property_scores(property_id, user_id, criterion_id, score, updated_at)`.
+  - `property_score_history(id, property_id, user_id, criterion_id, old_score, new_score, changed_at)` — written via DB trigger on insert/update of `property_scores`.
+  - `property_section_notes(property_id, user_id, section_id, body, visibility, updated_at)`.
+  - `criteria` lookup table (id, key, section_id, label, description, sort_order) and `criterion_sections` (id, key, label, description, sort_order). Seeded with the 22 + 3 from the brief.
+- **UI**: new `<ScoreChipRow>` component, new `<MinVurderingTab>` page, section accordions or scrollable sections, "lagret" indicator.
+- **Math**: total score becomes a derived value — see `comparison` for how individual + felles totals are calculated.
+- **Dependencies**: requires `households` (private to user within household), `properties` (foreign key). Blocks `comparison`, consumed by any totalscore display.

--- a/openspec/changes/scoring/specs/scoring/spec.md
+++ b/openspec/changes/scoring/specs/scoring/spec.md
@@ -1,0 +1,172 @@
+## ADDED Requirements
+
+### Requirement: Per-user score storage
+
+The system SHALL store each score as `(property_id, user_id, criterion_id, score)` where `score` is an integer in `[0, 10]`. The composite `(property_id, user_id, criterion_id)` SHALL be the primary key — there is exactly one score per user per criterion per property.
+
+#### Scenario: Insert a new score
+
+- **WHEN** a member upserts a score (8) for a property × criterion they haven't scored before
+- **THEN** a new `property_scores` row is inserted with `updated_at = now()`
+
+#### Scenario: Update an existing score
+
+- **WHEN** a member upserts a score (7) for a property × criterion they have already scored (was 8)
+- **THEN** the existing row's `score` is updated to 7 and `updated_at = now()`
+
+#### Scenario: Score out of range rejected
+
+- **WHEN** a user attempts to set `score = 11` or `score = -1`
+- **THEN** the database CHECK constraint rejects the operation
+
+#### Scenario: Cannot score on behalf of another user
+
+- **WHEN** a user attempts to insert a `property_scores` row with `user_id != auth.uid()`
+- **THEN** RLS denies the operation
+
+#### Scenario: Viewer cannot score
+
+- **WHEN** a `viewer` attempts to upsert a score
+- **THEN** RLS denies the operation
+
+#### Scenario: Non-member cannot score
+
+- **WHEN** a user not a member of the property's household attempts to upsert a score
+- **THEN** RLS denies the operation (the property is not in their household)
+
+### Requirement: Score change history
+
+The system SHALL automatically record every change to `property_scores` in `property_score_history` via an `AFTER INSERT OR UPDATE` trigger. History rows SHALL NOT be created for no-op updates (where the score didn't actually change).
+
+#### Scenario: Insert produces history row
+
+- **WHEN** a new score row is inserted (score 8)
+- **THEN** a history row is written with `old_score = NULL`, `new_score = 8`, `changed_at = now()`
+
+#### Scenario: Update produces history row
+
+- **WHEN** an existing score row is updated from 8 to 7
+- **THEN** a history row is written with `old_score = 8`, `new_score = 7`, `changed_at = now()`
+
+#### Scenario: No-op update produces no history
+
+- **WHEN** an UPDATE statement runs but the score value did not actually change
+- **THEN** no history row is written
+
+#### Scenario: History readable only by self
+
+- **WHEN** a user reads `property_score_history` for their own user_id in their household
+- **THEN** their history rows are returned
+
+#### Scenario: History not readable by other users
+
+- **WHEN** a user attempts to read another user's score history
+- **THEN** RLS returns no rows
+
+### Requirement: Min vurdering tab UI
+
+The system SHALL render the `Min vurdering` tab at `/app/bolig/[id]/min-vurdering` with: a counter ("X av 22 kriterier scoret"), three scored sections grouped by `criterion_section`, a chip-rad 0–10 per criterion, and a section-notes textarea per section.
+
+#### Scenario: Tab renders with counter
+
+- **WHEN** an owner/member opens `Min vurdering` for a property they have partially scored
+- **THEN** the counter shows the count of their scored criteria (e.g. "13 av 22")
+
+#### Scenario: Chip-rad selection
+
+- **WHEN** the user taps a chip (e.g. 7) on a criterion
+- **THEN** the chip fills with the primary color
+- **AND** the score is upserted to the database immediately (optimistic UI)
+- **AND** the counter increments if this was a previously unscored criterion
+
+#### Scenario: Re-score same criterion
+
+- **WHEN** the user taps a different chip on a criterion that was already scored
+- **THEN** the previous chip un-fills, the new one fills
+- **AND** the score is updated; counter is unchanged
+
+#### Scenario: Unscored criterion display
+
+- **WHEN** a criterion has no score for the current user
+- **THEN** the row shows all 11 chips outlined (no fill) and a small "— ikke scoret" label
+
+#### Scenario: Server save failure rolls back UI
+
+- **WHEN** the optimistic save returns an error
+- **THEN** the chip state reverts to its previous value
+- **AND** a toast displays "Kunne ikke lagre — prøv igjen"
+
+#### Scenario: Viewer cannot score
+
+- **WHEN** a `viewer` opens `Min vurdering`
+- **THEN** chips render but are disabled (no tap interaction)
+- **AND** the section-notes textareas are read-only
+
+### Requirement: Section notes
+
+The system SHALL provide one notes textarea per section (`Bolig innvendig`, `Beliggenhet & område`, `Helhet`) — one row per `(property_id, user_id, section_id)`. Notes default to `visibility = 'private'`. Notes SHALL autosave on blur and after a 1-second idle while typing.
+
+#### Scenario: Save note
+
+- **WHEN** a member types in the section notes textarea and pauses for 1 second
+- **THEN** the note is upserted to `property_section_notes`
+- **AND** an indicator shows "lagrer..." then "lagret"
+
+#### Scenario: Save on blur
+
+- **WHEN** a member types in the textarea and clicks outside (blur)
+- **THEN** the note is upserted immediately
+
+#### Scenario: Notes are private by default
+
+- **WHEN** a member writes a note for property P, section S
+- **THEN** the row is inserted with `visibility = 'private'`
+- **AND** the partner's `Min vurdering` tab does NOT show the note
+
+#### Scenario: Read own notes
+
+- **WHEN** a member reads notes for their own user × property × section
+- **THEN** the note body is returned
+
+#### Scenario: Cannot read partner's private notes
+
+- **WHEN** a member queries notes where `user_id != auth.uid()` AND `visibility = 'private'`
+- **THEN** RLS returns no rows
+
+### Requirement: Fakta section presentation
+
+The system SHALL render a `Fakta` section above the scored sections on the `Min vurdering` tab showing read-only values: `Pris/kvm`, `Størrelse (BRA)`, `Alder`. These values SHALL be computed on the fly from property data; missing inputs render as `—`.
+
+#### Scenario: All inputs available
+
+- **WHEN** a property has `price = 5_000_000`, `bra = 70`, `year_built = 2010`
+- **THEN** the Fakta section shows `Pris/kvm: 71 429 kr`, `Størrelse: 70 m²`, `Alder: 16 år` (current year 2026)
+
+#### Scenario: Missing price → derived value masked
+
+- **WHEN** a property has `price` null
+- **THEN** `Pris/kvm` is rendered as `—`
+
+#### Scenario: Fakta values are not editable
+
+- **WHEN** a user views the Fakta section
+- **THEN** no chip-rad or input is shown — only the computed values
+
+### Requirement: Score reading
+
+The system SHALL provide a function `get_property_with_scores(property_id, viewer_id)` returning: all property fields, the viewer's 22 scores (NULL where unscored), partner's score count (NOT individual scores — those leak the partner's vurdering), and total counts. RLS SHALL ensure the function only returns data for households the viewer is a member of.
+
+#### Scenario: Member fetches their property
+
+- **WHEN** a member calls `get_property_with_scores(p, themself)` for a property in their household
+- **THEN** the result includes the property + their 22 scores (NULL for unscored)
+
+#### Scenario: Partner score visibility leak prevented
+
+- **WHEN** a member fetches `get_property_with_scores`
+- **THEN** the response includes `partner_score_count` (e.g. "Kanta has scored 18 of 22") but NOT the individual partner scores
+
+#### Scenario: Non-member cannot fetch
+
+- **WHEN** a non-member calls the function
+- **THEN** the function returns no rows (RLS denies via the membership check)

--- a/openspec/changes/scoring/tasks.md
+++ b/openspec/changes/scoring/tasks.md
@@ -1,0 +1,60 @@
+> Conventions: see `openspec/conventions.md`.
+
+## 1. Database schema
+
+- [ ] 1.1 Migration: create `property_scores(property_id uuid REFERENCES properties(id) ON DELETE CASCADE, user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE, criterion_id uuid REFERENCES criteria(id) ON DELETE RESTRICT, score int NOT NULL CHECK (score BETWEEN 0 AND 10), updated_at timestamptz NOT NULL default now(), PRIMARY KEY (property_id, user_id, criterion_id))`. Index on `(property_id, user_id)` for the per-tab fetch.
+- [ ] 1.2 Migration: create `property_score_history(id uuid PK default gen_random_uuid(), property_id uuid NOT NULL, user_id uuid NOT NULL, criterion_id uuid NOT NULL, old_score int, new_score int NOT NULL, changed_at timestamptz NOT NULL default now())`. No FKs (history outlives the source row if scores deleted).
+- [ ] 1.3 Migration: create `property_section_notes(property_id uuid REFERENCES properties(id) ON DELETE CASCADE, user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE, section_id uuid REFERENCES criterion_sections(id) ON DELETE RESTRICT, body text NOT NULL default '', visibility text NOT NULL default 'private' CHECK (visibility IN ('private','shared')), updated_at timestamptz NOT NULL default now(), PRIMARY KEY (property_id, user_id, section_id))`.
+- [ ] 1.4 Trigger `property_scores_history_trg` AFTER INSERT OR UPDATE ON `property_scores` WHEN (OLD.score IS DISTINCT FROM NEW.score OR OLD IS NULL): insert into `property_score_history`.
+
+## 2. RLS policies
+
+- [ ] 2.1 Enable RLS on all three new tables.
+- [ ] 2.2 `property_scores` SELECT: caller is a member of the property's household (via JOIN to properties + has_household_role).
+- [ ] 2.3 `property_scores` INSERT/UPDATE/DELETE: `user_id = auth.uid()` AND caller has role `owner` or `member` in the property's household.
+- [ ] 2.4 `property_score_history` SELECT: `user_id = auth.uid()` AND member of the property's household. INSERT/UPDATE/DELETE: blocked at API (only the trigger writes; service-role on server-actions if needed).
+- [ ] 2.5 `property_section_notes` SELECT: caller is a member of the property's household AND (`visibility = 'shared'` OR `user_id = auth.uid()`). UPDATE/INSERT/DELETE: `user_id = auth.uid()` AND owner/member role.
+
+## 3. Server actions / data layer
+
+- [ ] 3.1 `setScore(propertyId, criterionId, score)` — upsert with `ON CONFLICT (property_id, user_id, criterion_id) DO UPDATE`. Returns the new score row + the updated `your_score_count` for the property.
+- [ ] 3.2 `clearScore(propertyId, criterionId)` — DELETE; counter decreases.
+- [ ] 3.3 `getMyScores(propertyId)` — returns 22 rows (one per criterion), with score or NULL.
+- [ ] 3.4 `getMyNotes(propertyId)` — returns 3 rows (one per section), creating empty rows if missing.
+- [ ] 3.5 `setNote(propertyId, sectionId, body)` — upsert.
+- [ ] 3.6 SQL function `get_property_with_scores(p_property_id uuid, p_viewer_id uuid)` returning property + viewer scores + viewer score count + partner score count (no partner scores leaked).
+
+## 4. UI — Min vurdering tab
+
+- [ ] 4.1 `app/app/bolig/[id]/min-vurdering/page.tsx` — server-fetches via `get_property_with_scores`; passes data to a client component for interaction.
+- [ ] 4.2 Counter at top: `"X av 22 kriterier scoret"`. Renders from `your_score_count`.
+- [ ] 4.3 `<FaktaSection>` component — read-only Pris/kvm, Størrelse, Alder. Uses property fields from the parent fetch.
+- [ ] 4.4 Three sections rendered with header + description; for each: list of criterion rows.
+- [ ] 4.5 `<ScoreChipRow>` component — 11 chips (0–10), selected chip filled. Touch target ≥ 44px each. Optimistic UI on tap.
+- [ ] 4.6 Section notes: `<SectionNotes>` textarea per section. Autosaves on blur + 1-second idle while typing. "lagrer..." / "lagret" indicator.
+- [ ] 4.7 Viewer mode: chips disabled, notes read-only (use `disabled` attribute and `aria-readonly`).
+
+## 5. Optimistic UI implementation
+
+- [ ] 5.1 `<ScoreChipRow>` receives `currentScore` from server data, holds an `optimisticScore` local state.
+- [ ] 5.2 On chip tap: set `optimisticScore` immediately; call `setScore` server action.
+- [ ] 5.3 On success: invalidate the parent fetch (Next.js `revalidatePath` or client-side query refetch).
+- [ ] 5.4 On error: revert `optimisticScore` to `currentScore`; show toast "Kunne ikke lagre — prøv igjen".
+
+## 6. Tests
+
+- [ ] 6.1 **Unit (Vitest)**: pris/kvm calculation with various inputs (handles null price, null bra); alder calculation (handles null year_built, year > current year + 5).
+- [ ] 6.2 **Integration**: insert-update round-trip; trigger writes history row; no-op update writes no history; CHECK rejects out-of-range.
+- [ ] 6.3 **Integration**: RLS — viewer cannot upsert; member cannot upsert with another user_id; non-member cannot SELECT scores or history; private notes hidden from partner.
+- [ ] 6.4 **Integration**: cascade — deleting a property removes scores and notes; deleting a member removes their scores.
+- [ ] 6.5 **Integration**: `get_property_with_scores` — viewer score count present, partner_score_count present, partner scores NOT in the response.
+- [ ] 6.6 **E2E (Playwright)**: open `Min vurdering`, tap a chip, see counter increment; reload, score persists.
+- [ ] 6.7 **E2E**: tap same chip twice (no change) — counter and chip state stable; no extra history rows (assert via SQL).
+- [ ] 6.8 **E2E**: type in section notes, blur, reload — note persists.
+- [ ] 6.9 **E2E**: optimistic-failure rollback — simulate server error (test mode), tap a chip, see chip revert + toast.
+- [ ] 6.10 **E2E**: viewer mode — chips disabled, notes read-only.
+
+## 7. Documentation
+
+- [ ] 7.1 `docs/architecture/scoring.md` — schema, history trigger, RLS, optimistic UI pattern.
+- [ ] 7.2 Update `docs/criteria.md` (from weights capability) to ensure the criteria list is canonical and shared.

--- a/openspec/changes/weights/.openspec.yaml
+++ b/openspec/changes/weights/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/weights/README.md
+++ b/openspec/changes/weights/README.md
@@ -1,0 +1,3 @@
+# weights
+
+Felles and personal weight adjustment for scoring criteria

--- a/openspec/changes/weights/design.md
+++ b/openspec/changes/weights/design.md
@@ -1,0 +1,103 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Context
+
+Different couples weigh different things. The brief calls for a `Vekter` page where the household maintains a **felles** weight set (used for `felles_total`) and each member maintains their **personal** weight set (used for `din_total`). Both sets always coexist; there is **no** "blank means use felles" override semantics. This makes the math simple and the UI honest — the user can always see exactly what weights they are using vs what the household consensus is.
+
+## Goals / Non-Goals
+
+**Goals:**
+- 22 criteria grouped into 3 sections (`Bolig innvendig`, `Beliggenhet & område`, `Helhet`), seeded as data.
+- Two parallel weight tables: `household_weights` (one row per household × criterion) and `user_weights` (one row per user × household × criterion).
+- Every household and member starts with all 22 weights set to `5` (mid-scale "moderat viktig").
+- `Vekter` page with a segmented control (`Felles vekter` / `Mine personlige vekter`).
+- Slider 0–10 per criterion. Personal view shows the felles weight as a small reference label next to each slider.
+- `owner` and `member` can edit; `viewer` is read-only.
+
+**Non-Goals:**
+- Live preview of how `totalscore` changes as the user moves a slider — explicitly droppable per the brief.
+- Real-time partner sync of felles weight edits — polling/refresh on focus is acceptable.
+- Per-criterion weight ranges (e.g. "Kjøkken can be 0–20 but Areal can only be 0–10") — uniform 0–10 across the board.
+- Weight history / audit log — not asked for; we can add later if needed.
+- "Reset to defaults" UI — implied but not explicit; we'll include a `Reset til standard (5 over hele linjen)` button on each view.
+
+## Decisions
+
+### D1. Two parallel tables, no override semantics
+
+**Choice**: `household_weights(household_id, criterion_id, weight)` and `user_weights(household_id, user_id, criterion_id, weight)` are both **fully populated** for every (household × criterion) and (user × household × criterion). There is no nullable "use felles" fallback.
+
+**Alternative considered**: nullable override (`user_weights.weight NULL` means "use household_weights").
+
+**Rationale**: user explicitly wants to see both weights side-by-side. With a nullable model, we'd have to coalesce on read AND make UX choices about what "blank" means in the slider (off? grey? = felles?). With both populated, the UI is unambiguous and the math is simple.
+
+### D2. Default weight = 5
+
+**Choice**: when seeded, every weight = `5`. Range is 0–10.
+
+**Rationale**: 5 is "moderat viktig" — a neutral starting point that requires the household to actively decide which criteria matter more. `0` would mean "criterion doesn't matter at all" which is too strong as a default — most criteria matter to some degree.
+
+### D3. Seeding via DB triggers
+
+**Choice**: two triggers handle seeding:
+- After insert on `households`: insert one `household_weights` row per criterion with `weight = 5`.
+- After insert on `household_members`: insert one `user_weights` row per criterion (for the new member, scoped to the joined household) with `weight = 5`.
+
+**Alternative considered**: do the seeding in application code (`createHousehold` server action seeds household_weights, `acceptInvitation` seeds user_weights).
+
+**Rationale**: triggers are atomic with the row insert and impossible to forget. Application-code seeding is bypassable by direct DB writes (e.g. a future bulk import script), which would create households missing weights. Triggers are the single source of truth.
+
+### D4. Criteria are seed data, not configurable
+
+**Choice**: `criteria` and `criterion_sections` are tables, but their rows are part of the schema migration — the 22 criteria and 3 sections are seeded by the migration and not user-editable.
+
+**Rationale**: the criteria list is part of the product spec; making it editable would require localization, validation, and migration logic for the score history when criteria change. None of that is needed for MVP. If we ever need to change the criteria list, we ship a new migration.
+
+### D5. Slider with discrete integer steps
+
+**Choice**: slider step = `1`. Values are integers 0–10. Use `<input type="range" min=0 max=10 step=1>` with custom Tailwind styling.
+
+**Rationale**: integer values are easier to reason about ("kjøkken er 8 av 10 viktig"). Floating-point weights add precision the user can't perceive. Discrete steps make keyboard a11y trivial (arrow keys = ±1).
+
+### D6. Reset action on each view
+
+**Choice**: each segmented-control view has a `Tilbakestill alle til 5` action. Confirms via dialog (destructive of changes).
+
+**Rationale**: weighted totals are sensitive to weights — easy to thrash. A reset gives users an escape hatch when they realize they over-tuned.
+
+### D7. Weights consumed by `comparison`'s totalscore math
+
+**Choice**: this capability does NOT compute totals. `din_total = Σ (your_score[c] × your_user_weight[c]) / Σ (your_user_weight[c]) × 10` and `felles_total = Σ (felles_score[c] × household_weight[c]) / Σ (household_weight[c]) × 10` are computed in the `comparison` capability and the `properties` list view.
+
+**Rationale**: separation of concerns. This capability owns weight management; comparison owns the math.
+
+### D8. Edge case: all weights are 0
+
+**Choice**: if every weight in a set is 0, `Σ weight = 0` and the formula divides by zero. Display "Ikke nok data" instead of a number.
+
+**Rationale**: rare but possible (user thinks "nothing matters"). Better than NaN.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Trigger fails silently if criteria table is empty | Migration order: criteria seeded BEFORE household-trigger creation. Integration test: creating a household always produces 22 weight rows. |
+| User accepts invitation to large existing household → trigger inserts 22 rows × N existing users? | The trigger inserts 22 rows for the *joining* user only, scoped to that household. Existing members already have their rows. |
+| Both partners edit the same felles weight at the same time | Last-write-wins; updated_by stamp shows who. No locking. |
+| User deletes themselves (leaves household) → user_weights orphaned | FK cascade: `user_weights.user_id → auth.users(id) ON DELETE CASCADE` AND `household_id → households(id)`. Combined with `household_members` cascade, the orphan can't persist. |
+| Reset button thrashes felles weights for both partners | The reset modal explicitly says "Dette tilbakestiller VEKTENE FOR HELE HUSHOLDNINGEN" when on the felles view. |
+| Missing user_weights rows for an existing user (bug, manual DB tinkering) | Defensive read in `comparison` math: `coalesce(user_weights.weight, 5)`. Also add a healthcheck that flags users missing weight rows. |
+
+## Resolved Decisions
+
+### D9. Personal view shows felles as small reference label, not as separate slider
+
+**Choice**: in the personal view, each row shows your slider + a small text reference "Felles: 7" next to it. NOT two parallel sliders.
+
+**Rationale**: avoids confusion about which slider is "yours". The reference is informative; editing felles is a separate view.
+
+### D10. Sliders are eager-save (no save button)
+
+**Choice**: changes save on slider release (`onMouseUp`/`onTouchEnd`/`onChange` settle). No "Lagre" button. Matches the autosave pattern from `scoring`.
+
+**Rationale**: consistent with the rest of the product. Brief explicitly mentions autosave for scoring; weights inherit the same model.

--- a/openspec/changes/weights/proposal.md
+++ b/openspec/changes/weights/proposal.md
@@ -1,0 +1,43 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Why
+
+Different couples weigh different things — for one household kjøkken is the deal-breaker, for another it's beliggenhet. v2 needs **two parallel weight sets**: a **felles** weight set (shared by the household, used in `felles_total`) and a **personal** weight set per user (private, used in `din_total`). Members see and use both side-by-side in the comparison view. This is more transparent than a "blank = use felles" override model — every weight is visible, no hidden fallbacks.
+
+## What Changes
+
+- New `Vekter` page (top-level nav item).
+- Segmented control at the top: `Felles vekter` (default) | `Mine personlige vekter`.
+- Same 22 criteria as `scoring`, grouped in the same three sections.
+- Per criterion: label + short description + **slider 0–10**. Default value: **5** (mid-scale, "moderat viktig").
+- **Felles vekter**: shared across the household. Either member's edits are visible to the other (after polling/refresh — no realtime in MVP). Used to compute `felles_total`.
+- **Personal vekter**: every user always has their own full set of 22 weights. Initialized to **5** (or copied from felles at the moment the user joins — implementation choice). Used to compute `din_total`.
+- Each row in the personal view also displays the **felles weight** as a small reference value next to the slider (e.g. "Felles: 7"), so the user can see how their personal weighting differs from the household consensus.
+- No live preview of how totalscore changes — out of scope for MVP. (Brief explicitly says droppable.)
+- **Role rules**:
+  - `owner`, `member`: can edit felles weights and their own personal weights.
+  - `viewer`: read-only on both.
+
+## Capabilities
+
+### New Capabilities
+- `weights`: 22-criteria weight management with both felles AND personal weight sets, segmented-control UI, slider component, side-by-side reference display in personal view.
+
+### Modified Capabilities
+<!-- None - new top-level capability. -->
+
+## Out of MVP scope (future)
+
+- **Live totalscore preview** as you drag sliders — explicitly droppable per the brief.
+- **Real-time sync** of felles weight changes across partner sessions — polling/refresh in MVP.
+
+## Impact
+
+- **Database**:
+  - `household_weights(household_id, criterion_id, weight INT 0..10, updated_at, updated_by)` — one row per (household × criterion).
+  - `user_weights(household_id, user_id, criterion_id, weight INT 0..10, updated_at)` — one row per (user × household × criterion). Always populated for all 22 criteria; no nullable override semantics.
+  - Trigger: when a new household is created, seed both tables with `weight = 5` for all 22 criteria. When a user joins a household, seed their `user_weights` with `weight = 5` for all 22 criteria.
+- **UI**: new `Vekter` page, slider component, segmented control, side-by-side personal-vs-felles row layout for the personal view.
+- **Math**: see `comparison` for how `din_total` (uses `user_weights`) and `felles_total` (uses `household_weights`) are calculated.
+- **Routes**: `/app/vekter`.
+- **Dependencies**: requires `households`. Consumed by `comparison` and any totalscore display in `properties`.

--- a/openspec/changes/weights/specs/weights/spec.md
+++ b/openspec/changes/weights/specs/weights/spec.md
@@ -1,0 +1,168 @@
+## ADDED Requirements
+
+### Requirement: Criteria and section seed data
+
+The system SHALL provide a seeded list of 22 scoring criteria grouped into 3 sections: `Bolig innvendig` (7 criteria), `Beliggenhet & område` (4 criteria), `Helhet` (2 criteria), plus a virtual `Fakta` section (3 derived facts that are NOT scored: pris/kvm, størrelse, alder). Wait — the brief lists 22 scored criteria; the section count totals to 13 explicit + 9 implicit. The seed list is authoritative; see tasks for the exact 22.
+
+#### Scenario: Criteria available
+
+- **WHEN** the database is migrated to v2
+- **THEN** `criterion_sections` contains the three scored sections
+- **AND** `criteria` contains exactly 22 rows linked to those sections
+
+#### Scenario: Criteria are read-only via API
+
+- **WHEN** any user attempts to insert/update/delete a `criteria` row
+- **THEN** the operation is denied (RLS denies non-service-role writes)
+
+### Requirement: Felles weights
+
+The system SHALL maintain a felles weight per (household × criterion). Every household SHALL have exactly 22 felles weight rows (one per criterion). All weights SHALL be integers in `[0, 10]`. Default value at seeding is `5`.
+
+#### Scenario: Household creation seeds felles weights
+
+- **WHEN** a new household is created
+- **THEN** the after-insert trigger inserts 22 rows into `household_weights` (one per criterion) with `weight = 5`
+
+#### Scenario: Owner edits felles weight
+
+- **WHEN** an `owner` updates a `household_weights` row to `weight = 8`
+- **THEN** the update succeeds and `updated_at` and `updated_by` are recorded
+
+#### Scenario: Member edits felles weight
+
+- **WHEN** a `member` updates a `household_weights` row
+- **THEN** the update succeeds
+
+#### Scenario: Viewer cannot edit felles weight
+
+- **WHEN** a `viewer` attempts to update `household_weights`
+- **THEN** RLS denies the operation
+
+#### Scenario: Weight out of range rejected
+
+- **WHEN** any user attempts to set `weight = 11` or `weight = -1`
+- **THEN** the database CHECK constraint rejects the update
+
+### Requirement: Personal weights
+
+The system SHALL maintain a personal weight per (user × household × criterion). Every member of a household SHALL have exactly 22 personal weight rows for that household (one per criterion). All weights SHALL be integers in `[0, 10]`. Default value at seeding is `5`.
+
+#### Scenario: Member join seeds personal weights
+
+- **WHEN** a user is added to a household (via invitation accept or owner-add)
+- **THEN** the after-insert trigger inserts 22 rows into `user_weights` for that user × household with `weight = 5`
+
+#### Scenario: User edits own personal weight
+
+- **WHEN** any role (`owner`/`member`/`viewer`) updates one of their own `user_weights` rows... wait — viewer is read-only EVERYWHERE. Re-state:
+
+#### Scenario: Owner/member edits own personal weight
+
+- **WHEN** an `owner` or `member` updates their own `user_weights` row
+- **THEN** the update succeeds
+
+#### Scenario: Viewer cannot edit personal weight
+
+- **WHEN** a `viewer` attempts to update their own `user_weights` (or anyone else's)
+- **THEN** RLS denies the operation
+- **AND** the UI does not render editable sliders for viewers
+
+#### Scenario: User cannot edit another user's personal weights
+
+- **WHEN** any user attempts to update a `user_weights` row where `user_id != auth.uid()`
+- **THEN** RLS denies the operation
+
+#### Scenario: Member leaving household deletes their personal weights
+
+- **WHEN** a `household_members` row is deleted
+- **THEN** all `user_weights` rows for that user × household are deleted via FK cascade
+
+### Requirement: Weight reset
+
+Every member with `owner` or `member` role SHALL be able to reset their personal weights to `5` across all 22 criteria in a single action. `owner` SHALL be able to reset the household's felles weights to `5` (members can reset felles weights too — D6 of design.md allows; restricting to owner is over-tight).
+
+#### Scenario: Personal reset
+
+- **WHEN** an `owner` or `member` confirms `Tilbakestill mine vekter til 5`
+- **THEN** all 22 of their `user_weights` rows in the active household are updated to `weight = 5`
+
+#### Scenario: Felles reset
+
+- **WHEN** an `owner` or `member` confirms `Tilbakestill felles vekter til 5`
+- **THEN** all 22 of `household_weights` rows for the active household are updated to `weight = 5`
+
+#### Scenario: Viewer cannot reset
+
+- **WHEN** a `viewer` attempts either reset
+- **THEN** RLS denies the operation and the UI hides the reset buttons
+
+### Requirement: Vekter page UI
+
+The system SHALL render `/app/vekter` with a segmented control (`Felles vekter` / `Mine personlige vekter`). Each view SHALL group the 22 criteria by their three sections and render a labeled slider 0–10 per criterion.
+
+#### Scenario: Default view is felles
+
+- **WHEN** an authenticated user with an active household navigates to `/app/vekter`
+- **THEN** the page renders with `Felles vekter` selected by default
+
+#### Scenario: Switch to personal
+
+- **WHEN** the user taps `Mine personlige vekter` on the segmented control
+- **THEN** the personal weights view renders
+- **AND** each row shows the felles weight as a small reference label (e.g. `Felles: 7`)
+
+#### Scenario: Slider edits autosave
+
+- **WHEN** the user releases a slider after dragging
+- **THEN** the new value is sent to the server via the corresponding update action
+- **AND** a subtle "lagret" indicator appears briefly
+
+#### Scenario: Sections render with headers
+
+- **WHEN** the page is rendered
+- **THEN** each section's heading + description appears above its 22-criteria sliders, in the canonical section order
+
+#### Scenario: Viewer sees read-only sliders
+
+- **WHEN** a `viewer` visits `/app/vekter`
+- **THEN** sliders render in disabled state with no thumb-drag interaction
+- **AND** reset buttons are hidden
+
+### Requirement: Weight retrieval API
+
+The system SHALL provide a function `getHouseholdWeights(household_id)` returning all 22 felles weights and a function `getUserWeights(household_id, user_id)` returning all 22 personal weights for the given user. Both SHALL respect RLS.
+
+#### Scenario: Get felles weights as member
+
+- **WHEN** a household member calls `getHouseholdWeights`
+- **THEN** all 22 rows are returned
+
+#### Scenario: Get felles weights as non-member
+
+- **WHEN** a non-member calls `getHouseholdWeights` for a household they don't belong to
+- **THEN** no rows are returned (RLS filters)
+
+#### Scenario: Get my own personal weights
+
+- **WHEN** a member calls `getUserWeights` for their own `user_id`
+- **THEN** all 22 rows are returned
+
+#### Scenario: Cannot read other user's personal weights
+
+- **WHEN** a member calls `getUserWeights` for another user
+- **THEN** no rows are returned (RLS filters at SELECT time)
+
+### Requirement: All-zero weights graceful handling
+
+When a weight set sums to `0`, the system SHALL display "Ikke nok data" (or equivalent) where a totalscore would normally be shown, instead of dividing by zero.
+
+#### Scenario: Felles total with all-zero felles weights
+
+- **WHEN** a household has all `household_weights.weight = 0`
+- **THEN** any UI that displays `felles_total` shows "Ikke nok data" in place of a number
+
+#### Scenario: Din total with all-zero personal weights
+
+- **WHEN** a user has all their `user_weights.weight = 0` for the active household
+- **THEN** any UI that displays `din_total` shows "Ikke nok data" in place of a number

--- a/openspec/changes/weights/tasks.md
+++ b/openspec/changes/weights/tasks.md
@@ -1,0 +1,66 @@
+> Conventions: see `openspec/conventions.md`.
+
+## 1. Database schema (criteria seed)
+
+- [ ] 1.1 Migration: create `criterion_sections(id uuid PK default gen_random_uuid(), key text NOT NULL UNIQUE, label text NOT NULL, description text, sort_order int NOT NULL)`.
+- [ ] 1.2 Migration: create `criteria(id uuid PK default gen_random_uuid(), key text NOT NULL UNIQUE, section_id uuid NOT NULL REFERENCES criterion_sections(id), label text NOT NULL, description text, sort_order int NOT NULL)`.
+- [ ] 1.3 Seed three sections: `bolig_innvendig` ("Bolig innvendig"), `beliggenhet_omrade` ("Beliggenhet & område"), `helhet` ("Helhet").
+- [ ] 1.4 Seed 22 criteria with the keys/labels from the design brief:
+  - Bolig innvendig: `kjokken`, `bad`, `planlosning`, `lys_luft`, `oppbevaring`, `stue`, `balkong_terrasse`.
+  - Beliggenhet & område: `omradeinntrykk`, `nabolag`, `transport`, `skoler`.
+  - Helhet: `visningsinntrykk`, `potensial`.
+  - Plus 9 more from v1's `ScoringCriterion` enum that match the brief (audit and reconcile to land on exactly 22). Document the final list in `docs/criteria.md`.
+
+## 2. Database schema (weight tables)
+
+- [ ] 2.1 Migration: create `household_weights(household_id uuid REFERENCES households(id) ON DELETE CASCADE, criterion_id uuid REFERENCES criteria(id) ON DELETE RESTRICT, weight int NOT NULL default 5 CHECK (weight BETWEEN 0 AND 10), updated_at timestamptz NOT NULL default now(), updated_by uuid REFERENCES auth.users(id), PRIMARY KEY (household_id, criterion_id))`.
+- [ ] 2.2 Migration: create `user_weights(household_id uuid REFERENCES households(id) ON DELETE CASCADE, user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE, criterion_id uuid REFERENCES criteria(id) ON DELETE RESTRICT, weight int NOT NULL default 5 CHECK (weight BETWEEN 0 AND 10), updated_at timestamptz NOT NULL default now(), PRIMARY KEY (household_id, user_id, criterion_id))`.
+- [ ] 2.3 Trigger on `households` AFTER INSERT: insert 22 rows into `household_weights` for the new household with `weight = 5`.
+- [ ] 2.4 Trigger on `household_members` AFTER INSERT: insert 22 rows into `user_weights` for the new (user × household) with `weight = 5`.
+
+## 3. RLS policies
+
+- [ ] 3.1 Enable RLS on `criteria`, `criterion_sections`, `household_weights`, `user_weights`.
+- [ ] 3.2 `criteria` and `criterion_sections`: SELECT for any authenticated user; no writes via API (service-role only via migration).
+- [ ] 3.3 `household_weights` SELECT: caller is member of `household_id`.
+- [ ] 3.4 `household_weights` UPDATE: `has_household_role(household_id, ARRAY['owner','member'])`. INSERT/DELETE blocked at API (handled by trigger only).
+- [ ] 3.5 `user_weights` SELECT: caller is member of `household_id` AND `user_id = auth.uid()` (you can only see your OWN personal weights, not your partner's). INSERT/DELETE blocked at API.
+- [ ] 3.6 `user_weights` UPDATE: same conditions as SELECT (only your own).
+
+## 4. Server actions / data layer
+
+- [ ] 4.1 `getCriteria()` — returns full list of criteria + sections, ordered.
+- [ ] 4.2 `getHouseholdWeights(householdId)` — returns 22 rows.
+- [ ] 4.3 `getUserWeights(householdId, userId)` — returns 22 rows. Server validates that `userId === auth.uid()` (defense-in-depth on top of RLS).
+- [ ] 4.4 `setHouseholdWeight(householdId, criterionId, weight)` — owner/member only.
+- [ ] 4.5 `setUserWeight(householdId, criterionId, weight)` — own weights only; owner/member roles only.
+- [ ] 4.6 `resetHouseholdWeights(householdId)` — bulk update to 5.
+- [ ] 4.7 `resetUserWeights(householdId)` — bulk update to 5 for caller.
+- [ ] 4.8 Helper `weightSetIsAllZero(rows)` — used by comparison math to detect divide-by-zero case.
+
+## 5. UI — Vekter page (`/app/vekter`)
+
+- [ ] 5.1 `app/app/vekter/page.tsx` — fetches `getCriteria` + `getHouseholdWeights` + `getUserWeights` in parallel.
+- [ ] 5.2 Segmented control at top: `Felles vekter` (default) / `Mine personlige vekter`. Active state via URL query param `?view=felles|personal` for shareable / browser-back behavior.
+- [ ] 5.3 Sections render in order with heading + description.
+- [ ] 5.4 Each row: criterion label (left), criterion description (small, below label), slider (right). On personal view: small "Felles: N" reference label between the criterion label and the slider.
+- [ ] 5.5 Slider component: Tailwind-styled native `<input type="range" min=0 max=10 step=1>`. Show current value as a number bubble or label. Touch-friendly thumb size.
+- [ ] 5.6 On slider release: call `setHouseholdWeight` or `setUserWeight`. Show "lagret" pulse on success.
+- [ ] 5.7 Reset button below each view: `Tilbakestill alle til 5`. Confirmation dialog before action.
+- [ ] 5.8 Viewer mode: sliders disabled (`<input disabled>`), reset hidden, segmented control still functional (they can view personal — well, only their own; viewers can have personal weights too, just read-only? clarify in tasks: viewers see their personal sliders disabled).
+
+## 6. Tests
+
+- [ ] 6.1 **Unit (Vitest)**: weight value validator (0–10 integers); `weightSetIsAllZero` helper.
+- [ ] 6.2 **Integration**: trigger seeding — create a household, assert 22 felles weight rows exist with weight=5; add a member, assert 22 personal weight rows exist for that user.
+- [ ] 6.3 **Integration**: RLS — viewer cannot UPDATE; member cannot UPDATE another user's `user_weights`; non-member cannot SELECT either weight table for a household they don't belong to.
+- [ ] 6.4 **Integration**: range CHECK rejects 11 and -1.
+- [ ] 6.5 **Integration**: deleting a member cascades to their `user_weights`; deleting a household cascades to both weight tables.
+- [ ] 6.6 **E2E (Playwright)**: open `/app/vekter`, drag a slider on felles view, reload, value persisted; switch to personal view, see felles reference label.
+- [ ] 6.7 **E2E**: reset action — drag a few sliders away from 5, click reset, confirm, all return to 5.
+- [ ] 6.8 **E2E**: viewer's `/app/vekter` shows disabled sliders.
+
+## 7. Documentation
+
+- [ ] 7.1 `docs/criteria.md` — full list of 22 criteria + 3 sections + descriptions, with the canonical English keys and Norwegian labels.
+- [ ] 7.2 `docs/architecture/weights.md` — schema, triggers, RLS, math contract with comparison.

--- a/openspec/conventions.md
+++ b/openspec/conventions.md
@@ -1,0 +1,81 @@
+# Boligscore v2 — Conventions
+
+Cross-cutting rules that apply to all 7 v2 capabilities. When a capability proposal contradicts something here, the proposal wins (and this file gets updated).
+
+## Language
+
+- **UI strings**: Norwegian bokmål, hardcoded as JSX literals. No i18n layer in MVP.
+  - Example: `<button>Bli med</button>`, `<h1>Score boliger sammen</h1>`.
+- **Code, identifiers, comments, route paths, database columns/tables**: English.
+  - Examples: `property`, `householdMembers`, `getCriteria()`, `/app/bolig/[id]`, `property_scores`, `created_at`.
+- Tables and columns: snake_case. TypeScript types and React components: PascalCase. Functions and variables: camelCase.
+- Future EN support: extract NO literals to `next-intl` JSON. Mechanical, deferrable.
+
+## Tech stack (locked for v2)
+
+- **Framework**: Next.js (App Router).
+- **Database & auth**: Supabase (Postgres + Auth + RLS + Storage).
+- **Styling**: Tailwind + CSS variables for theme tokens.
+- **PWA**: `next-pwa` or App-Router-compatible alternative.
+- **Email (local/dev)**: Mailpit (bundled with Supabase CLI local).
+- **Email (prod)**: Resend for invitations; Supabase built-in for magic link / password reset.
+- **Hosting**: Vercel (assumed).
+
+## Testing
+
+A capability is **done** only when:
+1. All unit tests pass.
+2. All integration tests pass against a Supabase CLI local instance.
+3. The listed e2e flows pass on a staging build.
+4. No new TypeScript or ESLint errors.
+
+### Test categories
+
+| Category | Tool | Scope |
+|---|---|---|
+| **Unit** | Vitest | Pure logic: math, role checks, validators, transforms. No external deps. Co-located as `*.test.ts`. |
+| **Integration** | Vitest + Supabase test client | Anything that touches the DB or RLS. Runs against Supabase CLI local. DB reset between tests via seed fixture. |
+| **E2E** | Playwright | Full user flows in a real browser. Auth bypass via `/dev/login` (env-gated). Email flows read captured messages from Mailpit's HTTP API. |
+
+### Minimum test floor per capability
+
+- `households`: unit (role helpers), integration (RLS for owner/member/viewer), e2e (invite → accept → switch household).
+- `properties`: unit (status helpers, validators), integration (CRUD with RLS, filter/sort SQL), e2e (add manually → list shows it → status change).
+- `scoring`: unit (counter, criteria grouping), integration (per-user isolation + history trigger writes), e2e (score 22 → counter updates → reload persists).
+- `comparison`: unit (`felles_total`, `din_total`, threshold detection math), integration (felles-score writes with role check), e2e (two users score → see |Δ| highlight → edit felles).
+- `weights`: unit (which weight set applies where), integration (seed-on-create trigger), e2e (drag slider → reload persists → felles & personal both render).
+- `navigation-shell`: e2e (routing across top-level pages, theme toggle persists, PWA installable, household switcher works).
+- `auth-onboarding`: e2e (landing → register → onboarding → invite via Mailpit → second account accepts → both see same household).
+
+### Test data
+
+- Seeded via `supabase/seed.sql` for local + e2e environments.
+- Default seed: 2 users (`alice@test.local`, `bob@test.local`, password `test1234`), 1 shared household, 3 properties at varied statuses.
+
+## Accessibility (floor — required across the app)
+
+- WCAG AA contrast minimum in both light and dark themes.
+- Status communicated by **icon + text + color** — never color alone.
+- Touch targets ≥ 44×44px on mobile.
+- Visible focus ring on interactive elements.
+- No hover-only interactions.
+
+## Mobile-first design rules
+
+- One-handed reach for primary CTAs (bottom nav, FAB).
+- Bottom sheets for filters; modals only for destructive confirmations.
+- Tabs horizontally scrollable on mobile when overflowing.
+- Desktop = responsive single-column with a max content width centered. No separate desktop layout.
+
+## Error and empty states
+
+Every screen needs both. Use shared components:
+- **Empty**: illustration + headline + supporting text + primary CTA.
+- **Error**: inline message preferred over modal, except destructive confirmations.
+- **Offline**: top banner "Du er offline — endringer lagres ikke" (no offline mutations in MVP).
+
+## OpenSpec process
+
+- Every capability proposal in `openspec/changes/<name>/proposal.md` includes a top reference: `> Conventions: see openspec/conventions.md`.
+- Deviations from this file must be called out explicitly in the proposal (in `Why` or a dedicated `## Deviations` section).
+- This file is updated whenever a deviation becomes the new norm.


### PR DESCRIPTION
Initialize OpenSpec with 7 capability changes (households, navigation-shell, auth-onboarding, properties, weights, scoring, comparison) capturing the v2 design brief from Stitch. Each change includes proposal, design, spec (with scenarios), and task checklist. Adds a cross-cutting conventions.md covering language, stack, testing, and a11y rules.

Tooling adapters limited to Claude Code, Codex, and GitHub (Copilot); unused tool adapters gitignored for re-runnable extension via `npx openspec init --tools <name>`.