### PR TITLE
v2: properties-finn-import — paste FINN URL → autofill the form

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,23 @@ the household's `Felles` total, and the user's `Din` total. Status is
 an extensible lookup — seven defaults ship as global rows; households
 may add custom statuses via the API.
 
+### Adding a property
+
+`/app/bolig/ny` opens a tabbed form:
+
+- **Fra FINN-lenke** (default) — paste a `https://www.finn.no/...` URL
+  and click "Hent fra FINN". The server fetches the listing, extracts
+  whatever fields it can (address, price, BRA, byggeår, boligtype,
+  primary image), and switches the form to **Manuelt** with the
+  parsed values prefilled. You can edit anything before saving. See
+  `docs/architecture/finn-import.md` for the parser strategy.
+- **Manuelt** — type every field by hand. Used when FINN-import
+  fails, the listing is private, or you're recording a place you
+  found offline.
+
+Either path saves through the same `createProperty` server action and
+lands in `/app/bolig/[id]/oversikt`.
+
 To get demo properties locally, `supabase db reset` runs
 `supabase/seed.sql` which seeds three properties at varied statuses
 (`vurderer`, `på visning`, `favoritt`) for the shared `Alice & Bob`

--- a/docs/architecture/finn-import.md
+++ b/docs/architecture/finn-import.md
@@ -1,0 +1,123 @@
+# FINN import — architecture notes
+
+> Spec source: `openspec/changes/properties-finn-import/{proposal,design,specs/properties-finn-import/spec.md}.md`.
+
+The `properties-finn-import` capability lets a user paste a FINN
+listing URL and prefill the `Ny bolig` form with whatever the parser
+could extract. The manual form remains the source of truth — D9 — so
+parsing is best-effort: a 30%-extracted listing is still 30% less
+typing than starting from blank.
+
+## Architecture at a glance
+
+```
+NyBoligForm (client)
+  ├─ Tab: "Fra FINN-lenke"  ──► fetch POST /api/properties/parse-finn
+  │                                 │
+  │                                 ▼
+  │                       src/app/api/properties/parse-finn/route.ts
+  │                                 │
+  │                       ┌─────────┴──────────┐
+  │                       ▼                    ▼
+  │              validateFinnUrl()     createSupabaseServerClient()
+  │              (D4 host allowlist)   (D5 auth gate)
+  │                       │
+  │                       ▼
+  │                fetchFinnHtml()
+  │              (D6 timeout + cap, D7 polite UA)
+  │                       │
+  │                       ▼
+  │                parseFinnHtml()
+  │              ┌────────┴───────┐
+  │              ▼                ▼
+  │   JSON-LD walker       CSS-selector fallback
+  │   (D1 primary)         (D1 fallback)
+  │              ▲                ▲
+  │              └────────┬───────┘
+  │                       │
+  │                  ParsedListing
+  │                  (partial — never throws)
+  │                       │
+  └────────◄ fetch response: { ok, data | error } ◄─┘
+                       │
+                       ▼
+                Tab switches to "Manuelt"
+                  + form fields prefilled
+                  + "Hentet N felter" notice
+```
+
+## JSON-LD-first parser strategy (D1)
+
+FINN's ad pages embed structured data as one or more
+`<script type="application/ld+json">` blocks. The parser walks every
+block and picks the first object whose `@type` matches a candidate
+list (`Product`, `Place`, `Residence`, `RealEstateListing`,
+`Apartment`, `House`, `SingleFamilyResidence`, `Accommodation`).
+FINN historically uses `Product`, but the candidate list keeps the
+parser working when they refactor.
+
+For fields the JSON-LD doesn't carry (or where it's malformed), the
+parser falls back to a labelled-value extractor that scans `<dl>`,
+`<table>`, and generic "label + sibling" patterns for Norwegian field
+names ("Bruksareal", "Byggeår", "Boligtype", …). Selectors are
+deliberately label-based rather than class-based — labels change less
+often than markup classes.
+
+The parser **never throws on a missing field**. Every field is
+optional; `extracted_fields` enumerates what was actually populated.
+
+## Fixture-based tests (D10)
+
+`tests/fixtures/finn/` holds checked-in HTML files used by the parser
+unit tests. The current set is **synthetic** — modeled after FINN's
+published markup but not captured from a real listing — because we
+didn't capture real FINN HTML in the original implementation loop. The
+file headers note this. Replace them with anonymized real captures
+when convenient; the test assertions target schema.org / common label
+patterns, so they should still pass.
+
+### Capturing a new fixture
+
+When FINN's HTML changes and the parser starts missing fields:
+
+1. Open the listing in your browser.
+2. View source / save HTML (no headless browsing — we want the static
+   server response, identical to what `fetchFinnHtml` will see).
+3. Anonymize:
+   - Replace phone numbers with `+47 99 99 99 99`.
+   - Replace agent names with `Eiendomsmegler Test`.
+   - Strip any unique IDs from URLs (`finnkode=X` is fine to keep —
+     it's already public).
+4. Save as `tests/fixtures/finn/listing-N.html`.
+5. Add a `describe` block in `src/lib/finn/parse.test.ts` for the new
+   fixture.
+
+## Resource limits (D6)
+
+`fetchFinnHtml` enforces:
+
+- **5-second timeout** via `AbortController`. Translates to
+  `FINN_ERROR_MESSAGES.fetchTimeout` ("FINN svarer ikke …").
+- **200 KB body cap**, checked first via `Content-Length` header and
+  then enforced while streaming the body. Translates to
+  `responseTooLarge`.
+
+Both bail with a typed `FinnFetchError`, which the route handler maps
+to a structured `{ ok: false, error: <Norwegian> }` response with
+status 200 (the route is structured-result-oriented — only auth/URL
+validation use 4xx codes, fetch failures are part of the success
+schema).
+
+## Future work / monitoring
+
+- **No rate-limiting today.** Auth gating (D5) keeps random-internet
+  abuse out, but a single user could still hammer the route. If we
+  see abuse, add a per-user counter in Postgres (counter row keyed by
+  `user_id`, reset every minute).
+- **No FINN HTML monitoring.** When FINN refactors and the CSS path
+  starts returning < 3 fields per call, we'd ideally alert. The route
+  handler has a `TODO(monitoring)` marker for this.
+- **No image storage.** We persist FINN's CDN URL on
+  `properties.image_url`. If FINN expires the URL, the property card
+  falls back to the placeholder. User-uploaded photos come in a
+  separate `properties-images` capability.

--- a/openspec/changes/properties-finn-import/.openspec.yaml
+++ b/openspec/changes/properties-finn-import/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/properties-finn-import/README.md
+++ b/openspec/changes/properties-finn-import/README.md
@@ -1,0 +1,3 @@
+# properties-finn-import
+
+Auto-fill property fields by parsing a FINN listing URL server-side

--- a/openspec/changes/properties-finn-import/design.md
+++ b/openspec/changes/properties-finn-import/design.md
@@ -1,0 +1,114 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Context
+
+User pastes a FINN listing URL (e.g. `https://www.finn.no/realestate/homes/ad.html?finnkode=123456789`). We need to fetch the page server-side, extract the fields the user would otherwise type by hand, and prefill the manual form. The user reviews and saves.
+
+Constraints:
+- **CORS**: browsers can't fetch FINN directly from the client. Server-side only.
+- **Robustness**: FINN's HTML changes. We can't depend on stable selectors. Two-tier extraction (JSON-LD primary, CSS fallback) reduces breakage rate.
+- **Politeness**: identify ourselves with a User-Agent string. Respect robots.txt (FINN allows scraping ad pages last I checked, but verify).
+- **No silent failures**: if parsing breaks, surface what we got + a clear "kunne ikke hente alle felter" notice; never block the user.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extract address, price, BRA, primærrom, bedrooms, year_built, property_type, image_url from a public FINN listing.
+- Surface partial extraction with a notice — never block the manual form.
+- Tab switcher in `NyBoligForm` between FINN and Manual input, FINN as default.
+- Server-side route handler (`/api/properties/parse-finn`) gated by authenticated session.
+- Tests run offline against checked-in HTML fixtures.
+
+**Non-Goals:**
+- Photo download / upload — only the FINN-hosted URL is stored.
+- Floor plan / nabolag / detailed amenities — too brittle, not worth.
+- Re-parse on URL update.
+- Multi-language listings — Norwegian-only.
+- Caching / rate-limiting — premature for v1; revisit if abuse appears.
+- Authenticated FINN scraping — public ads only.
+
+## Decisions
+
+### D1. Parse JSON-LD first, fall back to CSS selectors
+
+**Choice**: FINN embeds product/listing data as JSON-LD (`<script type="application/ld+json">`) on most ad pages. Try parsing that first. If it's missing or malformed, fall back to CSS selector–based extraction.
+
+**Rationale**: JSON-LD is structured and stable across markup refactors. CSS selectors work too but break when FINN renames classes. Two-tier extraction is more durable.
+
+### D2. Use `cheerio` for HTML parsing
+
+**Choice**: `cheerio` for HTML traversal. Fast, jQuery-like API, well-maintained.
+
+**Alternative considered**: `node-html-parser` (lighter), `linkedom` (DOM-compatible), `parse5`.
+
+**Rationale**: `cheerio` is the de-facto standard for server-side HTML scraping in Node. The API is approachable and the bundle cost only matters server-side anyway. We bundle one extra dep but gain much faster development.
+
+### D3. Parser runs in a Next.js Route Handler, not a Server Action
+
+**Choice**: `src/app/api/properties/parse-finn/route.ts` POST handler that accepts `{ url: string }` and returns `{ ok: true, data: ParsedListing }` or `{ ok: false, error: string }`.
+
+**Alternative considered**: Server Action invoked directly from `NyBoligForm`.
+
+**Rationale**: a Route Handler keeps the parser's runtime decoupled from React's render cycle. Easier to add rate limiting, easier to call from tests, can be moved to an Edge Function later. Server Actions are great for mutations bound to a form; this is a *read* triggered by a button.
+
+### D4. URL whitelist — only `finn.no` hosts
+
+**Choice**: validate `new URL(input).hostname === 'www.finn.no' || === 'finn.no'`. Reject everything else.
+
+**Rationale**: prevents the parser from being abused as a generic SSRF — someone POSTing `http://internal-service:8080/secrets` would otherwise give them whatever that returns. Hostname allowlist closes the obvious hole.
+
+### D5. Authenticated callers only
+
+**Choice**: the route handler reads the Supabase session via `createSupabaseServerClient()` and rejects unauthenticated callers with 401.
+
+**Rationale**: this is a write-adjacent action that costs network bandwidth on our side. Unauthenticated random-internet calls are abuse. Session check is one-line.
+
+### D6. 5-second fetch timeout, 200KB response cap
+
+**Choice**: `fetch()` with `AbortController`, timeout 5 seconds. Read body up to 200KB and bail. Return a clear error if exceeded.
+
+**Rationale**: defends against (a) FINN being slow/down (we want fast UI feedback), (b) malicious URLs returning huge responses, (c) accidentally proxying a non-HTML URL.
+
+### D7. User-Agent identifies us
+
+**Choice**: `User-Agent: Boligscore/1.0 (+https://boligscore.app)`.
+
+**Rationale**: standard scraper etiquette. Lets FINN identify and contact us if they want.
+
+### D8. Partial-success path
+
+**Choice**: parser returns `{ ok: true, data: { address, price, bra, ..., extracted_fields: ['address', 'price'] } }` even when some fields are missing. UI shows a notice listing which fields were prefilled and which were left blank.
+
+**Rationale**: a 30%-extracted listing is still 30% less typing. Don't let the perfect be the enemy of the good.
+
+### D9. The manual form remains the source of truth
+
+**Choice**: after a successful parse, the prefilled values land in `NyBoligForm` form state — **not** auto-submitted. The user reviews, edits, and submits. Same `createProperty` server action as before.
+
+**Rationale**: parsing can be wrong (mislabeled rooms, price in NOK vs kr, etc.). Always letting the user review prevents bad data and keeps the user in control.
+
+### D10. Fixtures-based tests
+
+**Choice**: check in 2–3 anonymized FINN listing HTML files at `tests/fixtures/finn/`. Parser tests run against those. CI never hits the real FINN.
+
+**Rationale**: deterministic, fast, doesn't depend on FINN being up. Re-record fixtures when the parser breaks against a real listing.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| FINN changes HTML, parser breaks silently | JSON-LD-first reduces breakage. Manual fallback always works. Add a Sentry/log alert when CSS path returns < 3 fields, so we notice. |
+| FINN blocks our user-agent / IP | Polite UA. If blocked, fall back to "kunne ikke hente — fyll inn manuelt". User-facing impact is clear. |
+| User pastes a non-FINN URL | Hostname allowlist (D4) rejects with a clear Norwegian error. |
+| Parser becomes brittle and noisy | Each extracted field is best-effort, optional. Missing fields render `—` in the form, user fills in. |
+| Slow FINN responses block the UI | 5s timeout (D6); UI shows spinner with cancel-button affordance. |
+| Image URL expires after FINN takes the listing down | Property card already falls back to placeholder when `image_url` is null OR fails to load. Acceptable. |
+| Server gets DDOS'd via parse-finn | Authenticated callers only (D5). Add a per-user rate limit if abuse shows up. |
+
+## Resolved decisions
+
+### D11. Tab order: FINN as default
+
+**Choice**: when the user lands on `Ny bolig`, the FINN tab is selected and focused. Manual is one tap away.
+
+**Rationale**: matches the brief ("Fra FINN-lenke (default, anbefalt)"). Most users will arrive with a URL in mind; manual is the fallback.

--- a/openspec/changes/properties-finn-import/proposal.md
+++ b/openspec/changes/properties-finn-import/proposal.md
@@ -1,0 +1,43 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Why
+
+The MVP `properties` capability ships manual entry only — adding a property means typing in 10+ fields (address, price, costs, BRA, primary rooms, bedrooms, bathrooms, year built, type, floor). The original Stitch design brief calls FINN-import the **default** path because the primary use-case is "I just saw a listing on FINN and want to score it." Manual entry is friction users will route around (or just stop using the app).
+
+User feedback after the first launch confirms this: the first piece of feedback received was that "fakta som kan hentes av FINN annonsen burde bli lagt inn selv". Auto-fill is the highest-leverage UX win.
+
+## What Changes
+
+- New **server-side FINN parser** that accepts a FINN listing URL and returns a structured object with the fields it could extract.
+- Activate the **"Fra FINN-lenke" tab** in `NyBoligForm` (currently hidden per `properties` D10). The tab gets a single URL input, a "Hent fra FINN"-knapp, and on success prefills the manual form (which is reused — same component, same validation, same submit). User can review/edit anything before saving.
+- **Failure path**: parse errors fall back to the manual form with whatever was extracted (often address + image_url even when prices are weird). Always non-blocking — a parse error never prevents adding the property manually.
+- Store the source FINN URL on `properties.finn_link` (already exists) and the listing's primary image URL on a new `properties.image_url` column (also already exists in schema, currently always null).
+- The parser is invoked via a Next.js Route Handler (`/api/properties/parse-finn`) so the heavy work runs server-side and we can add per-user rate limiting later.
+- **No image storage** — we only store the URL pointing at FINN's CDN. If FINN later expires or moves the image, we degrade gracefully to the placeholder. Real photo upload comes in a separate `properties-images` capability.
+
+## Out of MVP scope (future)
+
+- **Photo upload** — store user-uploaded photos in Supabase Storage. Separate change `properties-images`.
+- **Re-parse on URL change** — the parser runs once when the user pastes the URL; updating the FINN-link later doesn't re-trigger it. If a listing changes price/details, the user re-imports manually.
+- **FINN account integration** — no API key, no scraped private data. Public listing pages only.
+- **Bulk import** — single-URL entry only.
+- **Caching** — every parse is a fresh HTTP fetch. If we hit rate-limits or want to amortize cost, add a Redis cache later.
+- **Deep field extraction** — fields beyond the basics (e.g. `omkostninger`, `felleskostnader`, primærrom split) are best-effort. Anything we can't reliably extract is left blank for the user to fill in.
+
+## Capabilities
+
+### New Capabilities
+- `properties-finn-import`: server-side FINN HTML parser, parse-FINN Route Handler, "Fra FINN-lenke" tab UI, prefill flow into NyBoligForm.
+
+### Modified Capabilities
+- `properties`: the "Fra FINN-lenke" tab is no longer hidden (D10 reversed). Surface a tab switcher above the form. The default tab depends on whether `image_url` should be displayed in `OversiktView` (out of scope for this change — list-card placeholder thumbnail stays).
+
+## Impact
+
+- **Backend**: new `src/lib/finn/parse.ts` module + `src/app/api/properties/parse-finn/route.ts` handler. Adds `cheerio` (or `node-html-parser`) as a runtime dependency.
+- **UI**: `NyBoligForm` gets a tab switcher and a URL input mode. Reuses the existing manual fields for review/edit.
+- **Database**: `properties.image_url` column already exists (text, nullable). No schema change required.
+- **Network**: every parse triggers an outbound HTTPS GET to `https://www.finn.no/...`. No auth; user-agent set politely. Errors handled (timeout, 404, redirect, blocked) without crashing the page.
+- **Rate limiting**: not in this change — start without it, add a per-user counter later if abuse appears.
+- **Tests**: parser tests with checked-in FINN HTML fixtures (so tests are offline). UI test for the prefill round-trip.
+- **Robustness caveat**: FINN can change their HTML at any time. The parser must degrade gracefully — extract what it can, leave the rest empty, never crash. A monitoring/alerting story comes later.

--- a/openspec/changes/properties-finn-import/specs/properties-finn-import/spec.md
+++ b/openspec/changes/properties-finn-import/specs/properties-finn-import/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: FINN URL parsing
+
+The system SHALL accept a FINN listing URL and return as many extracted property fields as it can. Missing fields SHALL be reported as missing — they SHALL NOT cause the entire parse to fail.
+
+#### Scenario: Successful parse
+
+- **WHEN** an authenticated user submits a valid FINN URL via `POST /api/properties/parse-finn`
+- **THEN** the response is `{ ok: true, data: { address, price, bra, year_built, property_type, image_url, finn_link, extracted_fields: [...] } }`
+- **AND** `extracted_fields` lists which keys were populated (omitted keys are null)
+
+#### Scenario: Partial parse
+
+- **WHEN** the FINN page exposes only some of the target fields
+- **THEN** the response is `{ ok: true, data: ... }` with the available fields populated and the rest null
+- **AND** `extracted_fields` reflects only what was found
+
+#### Scenario: Network failure
+
+- **WHEN** the upstream FINN fetch fails (timeout, 4xx, 5xx, DNS)
+- **THEN** the response is `{ ok: false, error: <user-facing Norwegian message> }`
+- **AND** the manual form remains usable (the UI does NOT block)
+
+### Requirement: URL allowlist
+
+The system SHALL only fetch URLs whose hostname is exactly `www.finn.no` or `finn.no`. Any other hostname SHALL be rejected without making a network request.
+
+#### Scenario: Non-FINN URL rejected
+
+- **WHEN** a user POSTs `{ url: "http://example.com/anything" }`
+- **THEN** the response is `{ ok: false, error: "URL må være en FINN-annonse" }` with status 400
+- **AND** no outbound HTTP request is made
+
+#### Scenario: Malformed URL rejected
+
+- **WHEN** a user POSTs `{ url: "not a url" }`
+- **THEN** the response is `{ ok: false, error: <validation message> }` with status 400
+
+#### Scenario: HTTP scheme accepted
+
+- **WHEN** a user POSTs `{ url: "https://www.finn.no/..." }` or `{ url: "https://finn.no/..." }`
+- **THEN** the parser proceeds
+
+### Requirement: Authentication required
+
+The parser endpoint SHALL require an authenticated Supabase session. Unauthenticated requests SHALL receive 401.
+
+#### Scenario: Unauthenticated request denied
+
+- **WHEN** a request to `/api/properties/parse-finn` carries no valid session cookie
+- **THEN** the response is `{ ok: false, error: "Du må være logget inn" }` with status 401
+- **AND** no outbound fetch is performed
+
+### Requirement: Resource limits
+
+The parser SHALL enforce a 5-second timeout on the upstream fetch and a 200 KB cap on the response body. Exceeding either SHALL produce a controlled error.
+
+#### Scenario: Timeout
+
+- **WHEN** FINN takes longer than 5 seconds to respond
+- **THEN** the parser aborts the fetch and returns `{ ok: false, error: "FINN svarer ikke — prøv igjen senere eller fyll inn manuelt" }`
+
+#### Scenario: Oversized response
+
+- **WHEN** the response body exceeds 200 KB
+- **THEN** the parser stops reading and returns `{ ok: false, error: <message> }`
+
+### Requirement: NyBoligForm tab switcher
+
+The system SHALL render two tabs above `NyBoligForm`: `Fra FINN-lenke` (default, focused) and `Manuelt`. The FINN tab SHALL contain a URL input and a "Hent fra FINN" button. On success, the parsed values SHALL prefill the manual form fields without auto-submitting.
+
+#### Scenario: Default tab is FINN
+
+- **WHEN** an `owner` or `member` navigates to `/app/bolig/ny`
+- **THEN** the `Fra FINN-lenke` tab is active
+- **AND** the URL input has focus
+
+#### Scenario: Successful prefill
+
+- **WHEN** the user submits a valid FINN URL and the parse succeeds with at least 3 fields
+- **THEN** the form switches to the Manual tab with the parsed values populated
+- **AND** a notice displays "Hentet N felter fra FINN — sjekk og rediger ved behov"
+
+#### Scenario: Partial prefill
+
+- **WHEN** the parse succeeds but only some fields were extracted
+- **THEN** the form prefills the available fields and leaves the others blank
+- **AND** the notice lists which fields were prefilled
+
+#### Scenario: Parse failure falls back to manual
+
+- **WHEN** the parser returns `{ ok: false }`
+- **THEN** an inline error displays the Norwegian error message
+- **AND** the form remains usable in the FINN tab (user can retry) or the user can switch to Manual
+
+#### Scenario: Manual tab is unaffected
+
+- **WHEN** the user starts on `Manuelt` and types in fields
+- **AND** does not switch tabs
+- **THEN** the form behaves exactly as before — no parser interaction, same submit flow
+
+### Requirement: Parsed fields land on the property record
+
+When the user reviews the prefilled form and submits, the resulting `properties` row SHALL store the parsed values that the user did not edit. The `finn_link` SHALL store the original FINN URL. The `image_url` (if extracted) SHALL be stored.
+
+#### Scenario: Saving after a successful prefill
+
+- **WHEN** the user prefills via FINN and submits without further edits
+- **THEN** the inserted row contains the parsed `address`, `price`, `bra`, `year_built`, `property_type`, `finn_link` (= the input URL), and `image_url` (if extracted)
+
+#### Scenario: User edits before saving
+
+- **WHEN** the user prefills via FINN and changes a field before submitting
+- **THEN** the inserted row contains the user's edited value, not the parsed one

--- a/openspec/changes/properties-finn-import/tasks.md
+++ b/openspec/changes/properties-finn-import/tasks.md
@@ -2,8 +2,8 @@
 
 ## 1. Dependencies + scaffolding
 
-- [ ] 1.1 Add `cheerio` to `package.json` dependencies. Also `@types/cheerio` if not already pulled in transitively.
-- [ ] 1.2 Verify `properties.image_url` column exists (it does — added by `properties` capability stub). If absent, add a small migration.
+- [x] 1.1 Add `cheerio` to `package.json` dependencies. Also `@types/cheerio` if not already pulled in transitively.
+- [x] 1.2 Verify `properties.image_url` column exists (it does — added by `properties` capability stub). If absent, add a small migration.
 
 ## 2. Parser library
 

--- a/openspec/changes/properties-finn-import/tasks.md
+++ b/openspec/changes/properties-finn-import/tasks.md
@@ -48,9 +48,9 @@
 
 ## 7. Documentation
 
-- [ ] 7.1 `docs/architecture/finn-import.md` — JSON-LD-first parser strategy, fixture-based tests, how to capture a new fixture when FINN's HTML changes.
-- [ ] 7.2 Update `properties` proposal `## Out of MVP scope` section: remove the FINN bullet (it's no longer deferred).
-- [ ] 7.3 Update `README.md` "Adding a property" section to mention the FINN paste path.
+- [x] 7.1 `docs/architecture/finn-import.md` — JSON-LD-first parser strategy, fixture-based tests, how to capture a new fixture when FINN's HTML changes.
+- [x] 7.2 Update `properties` proposal `## Out of MVP scope` section: remove the FINN bullet (it's no longer deferred).
+- [x] 7.3 Update `README.md` "Adding a property" section to mention the FINN paste path.
 
 ## 8. Operational
 

--- a/openspec/changes/properties-finn-import/tasks.md
+++ b/openspec/changes/properties-finn-import/tasks.md
@@ -7,13 +7,13 @@
 
 ## 2. Parser library
 
-- [ ] 2.1 Create `src/lib/finn/types.ts` with `ParsedListing` and `ParseResult` discriminated union.
-- [ ] 2.2 Create `src/lib/finn/parse.ts` exporting `async parseFinnHtml(html: string): Promise<ParsedListing>`. Order:
+- [x] 2.1 Create `src/lib/finn/types.ts` with `ParsedListing` and `ParseResult` discriminated union.
+- [x] 2.2 Create `src/lib/finn/parse.ts` exporting `async parseFinnHtml(html: string): Promise<ParsedListing>`. Order:
    - Try JSON-LD extraction first (look for `<script type="application/ld+json">` containing `@type: "Product"` or `"Place"`/`"RealEstateListing"`).
    - Fall back to CSS selectors for fields not found in JSON-LD.
    - Always return a partial — never throw on missing fields.
-- [ ] 2.3 Create `src/lib/finn/fetch.ts` exporting `async fetchFinnHtml(url: string): Promise<string>` with the 5-second timeout, 200 KB body cap, and the polite `User-Agent`.
-- [ ] 2.4 URL validator helper `validateFinnUrl(input: string): { ok: true; url: URL } | { ok: false; error: string }` enforcing the hostname allowlist (D4). Reject any non-`finn.no` host.
+- [x] 2.3 Create `src/lib/finn/fetch.ts` exporting `async fetchFinnHtml(url: string): Promise<string>` with the 5-second timeout, 200 KB body cap, and the polite `User-Agent`.
+- [x] 2.4 URL validator helper `validateFinnUrl(input: string): { ok: true; url: URL } | { ok: false; error: string }` enforcing the hostname allowlist (D4). Reject any non-`finn.no` host.
 
 ## 3. Route Handler
 

--- a/openspec/changes/properties-finn-import/tasks.md
+++ b/openspec/changes/properties-finn-import/tasks.md
@@ -1,0 +1,58 @@
+> Conventions: see `openspec/conventions.md`.
+
+## 1. Dependencies + scaffolding
+
+- [ ] 1.1 Add `cheerio` to `package.json` dependencies. Also `@types/cheerio` if not already pulled in transitively.
+- [ ] 1.2 Verify `properties.image_url` column exists (it does — added by `properties` capability stub). If absent, add a small migration.
+
+## 2. Parser library
+
+- [ ] 2.1 Create `src/lib/finn/types.ts` with `ParsedListing` and `ParseResult` discriminated union.
+- [ ] 2.2 Create `src/lib/finn/parse.ts` exporting `async parseFinnHtml(html: string): Promise<ParsedListing>`. Order:
+   - Try JSON-LD extraction first (look for `<script type="application/ld+json">` containing `@type: "Product"` or `"Place"`/`"RealEstateListing"`).
+   - Fall back to CSS selectors for fields not found in JSON-LD.
+   - Always return a partial — never throw on missing fields.
+- [ ] 2.3 Create `src/lib/finn/fetch.ts` exporting `async fetchFinnHtml(url: string): Promise<string>` with the 5-second timeout, 200 KB body cap, and the polite `User-Agent`.
+- [ ] 2.4 URL validator helper `validateFinnUrl(input: string): { ok: true; url: URL } | { ok: false; error: string }` enforcing the hostname allowlist (D4). Reject any non-`finn.no` host.
+
+## 3. Route Handler
+
+- [ ] 3.1 Create `src/app/api/properties/parse-finn/route.ts` exporting an async `POST` handler.
+- [ ] 3.2 Auth check via `createSupabaseServerClient()`; 401 if no session.
+- [ ] 3.3 Validate the URL via `validateFinnUrl`; 400 on bad input.
+- [ ] 3.4 Fetch the page via `fetchFinnHtml`; surface fetch errors with Norwegian messages.
+- [ ] 3.5 Parse via `parseFinnHtml`; build the `ParsedListing` response.
+- [ ] 3.6 Return JSON: `{ ok: true, data: ParsedListing }` or `{ ok: false, error: string }`. Never 500 on a parse problem — always a structured `ok: false`.
+
+## 4. UI — NyBoligForm tabs
+
+- [ ] 4.1 Add a tab strip above the form: `Fra FINN-lenke` (default, focused) | `Manuelt`. Tabs match the existing PropertyTabs style (underline + primary).
+- [ ] 4.2 FINN tab body: URL input (`<input type="url" placeholder="https://www.finn.no/...">`), "Hent fra FINN" submit button, optional `<a>` to "Eller fyll inn manuelt" that switches tabs.
+- [ ] 4.3 Manual tab body: existing form sections, unchanged.
+- [ ] 4.4 Persist tab choice in `useState`, not URL — refreshes reset to FINN default.
+
+## 5. UI — fetch + prefill flow
+
+- [ ] 5.1 On "Hent fra FINN" click: client POST to `/api/properties/parse-finn` with `{ url }`. Show inline spinner.
+- [ ] 5.2 On success: switch to the Manual tab with form values prefilled from the parsed data. Show a non-blocking info banner: `Hentet {N} felter fra FINN — sjekk og rediger ved behov.`
+- [ ] 5.3 On failure: show an inline error with the server's Norwegian message. The user can retry with a different URL or switch to Manual.
+- [ ] 5.4 On any user edit after prefill: keep the user's edit. Never re-trigger the parser unless the user explicitly clicks "Hent fra FINN" again.
+
+## 6. Tests
+
+- [ ] 6.1 **Unit (Vitest)**: `validateFinnUrl` — accept valid finn.no, reject other hosts, reject malformed URLs, accept both `finn.no` and `www.finn.no`.
+- [ ] 6.2 **Unit**: `parseFinnHtml` against checked-in fixtures (`tests/fixtures/finn/listing-1.html`, `listing-2.html`). Cover: full extraction, partial extraction, JSON-LD missing → CSS fallback, garbage input.
+- [ ] 6.3 **Unit**: `fetchFinnHtml` mock-fetch with `vi.mock('node:fetch')` (or `undici` mocks). Cover timeout, 404, 5xx, oversized body.
+- [ ] 6.4 **Integration / Route**: `POST /api/properties/parse-finn` — happy path, unauthenticated 401, non-FINN URL 400, fetch failure → `ok: false`.
+- [ ] 6.5 **E2E (Playwright)**: open `/app/bolig/ny` → FINN tab focused → paste URL (mocked via Playwright's `route()` interceptor) → parse → form prefills → save → property visible on `/app`.
+
+## 7. Documentation
+
+- [ ] 7.1 `docs/architecture/finn-import.md` — JSON-LD-first parser strategy, fixture-based tests, how to capture a new fixture when FINN's HTML changes.
+- [ ] 7.2 Update `properties` proposal `## Out of MVP scope` section: remove the FINN bullet (it's no longer deferred).
+- [ ] 7.3 Update `README.md` "Adding a property" section to mention the FINN paste path.
+
+## 8. Operational
+
+- [ ] 8.1 Add `cheerio` to `package.json` (already in 1.1 — keep one source).
+- [ ] 8.2 Add a `// TODO(monitoring)` comment in the route handler noting where to add a Sentry/log call when parser extraction count drops below a threshold (e.g. < 3 fields). The actual instrumentation is deferred until we have a logging backend.

--- a/openspec/changes/properties-finn-import/tasks.md
+++ b/openspec/changes/properties-finn-import/tasks.md
@@ -40,11 +40,11 @@
 
 ## 6. Tests
 
-- [ ] 6.1 **Unit (Vitest)**: `validateFinnUrl` — accept valid finn.no, reject other hosts, reject malformed URLs, accept both `finn.no` and `www.finn.no`.
-- [ ] 6.2 **Unit**: `parseFinnHtml` against checked-in fixtures (`tests/fixtures/finn/listing-1.html`, `listing-2.html`). Cover: full extraction, partial extraction, JSON-LD missing → CSS fallback, garbage input.
-- [ ] 6.3 **Unit**: `fetchFinnHtml` mock-fetch with `vi.mock('node:fetch')` (or `undici` mocks). Cover timeout, 404, 5xx, oversized body.
-- [ ] 6.4 **Integration / Route**: `POST /api/properties/parse-finn` — happy path, unauthenticated 401, non-FINN URL 400, fetch failure → `ok: false`.
-- [ ] 6.5 **E2E (Playwright)**: open `/app/bolig/ny` → FINN tab focused → paste URL (mocked via Playwright's `route()` interceptor) → parse → form prefills → save → property visible on `/app`.
+- [x] 6.1 **Unit (Vitest)**: `validateFinnUrl` — accept valid finn.no, reject other hosts, reject malformed URLs, accept both `finn.no` and `www.finn.no`.
+- [x] 6.2 **Unit**: `parseFinnHtml` against checked-in fixtures (`tests/fixtures/finn/listing-1.html`, `listing-2.html`). Cover: full extraction, partial extraction, JSON-LD missing → CSS fallback, garbage input.
+- [x] 6.3 **Unit**: `fetchFinnHtml` mock-fetch with `vi.mock('node:fetch')` (or `undici` mocks). Cover timeout, 404, 5xx, oversized body.
+- [x] 6.4 **Integration / Route**: `POST /api/properties/parse-finn` — happy path, unauthenticated 401, non-FINN URL 400, fetch failure → `ok: false`.
+- [~] 6.5 **E2E (Playwright)**: open `/app/bolig/ny` → FINN tab focused → paste URL (mocked via Playwright's `route()` interceptor) → parse → form prefills → save → property visible on `/app`. (Authored as `test.fixme()` — flips on with the existing Supabase + dev-users harness.)
 
 ## 7. Documentation
 

--- a/openspec/changes/properties-finn-import/tasks.md
+++ b/openspec/changes/properties-finn-import/tasks.md
@@ -26,17 +26,17 @@
 
 ## 4. UI — NyBoligForm tabs
 
-- [ ] 4.1 Add a tab strip above the form: `Fra FINN-lenke` (default, focused) | `Manuelt`. Tabs match the existing PropertyTabs style (underline + primary).
-- [ ] 4.2 FINN tab body: URL input (`<input type="url" placeholder="https://www.finn.no/...">`), "Hent fra FINN" submit button, optional `<a>` to "Eller fyll inn manuelt" that switches tabs.
-- [ ] 4.3 Manual tab body: existing form sections, unchanged.
-- [ ] 4.4 Persist tab choice in `useState`, not URL — refreshes reset to FINN default.
+- [x] 4.1 Add a tab strip above the form: `Fra FINN-lenke` (default, focused) | `Manuelt`. Tabs match the existing PropertyTabs style (underline + primary).
+- [x] 4.2 FINN tab body: URL input (`<input type="url" placeholder="https://www.finn.no/...">`), "Hent fra FINN" submit button, optional `<a>` to "Eller fyll inn manuelt" that switches tabs.
+- [x] 4.3 Manual tab body: existing form sections, unchanged.
+- [x] 4.4 Persist tab choice in `useState`, not URL — refreshes reset to FINN default.
 
 ## 5. UI — fetch + prefill flow
 
-- [ ] 5.1 On "Hent fra FINN" click: client POST to `/api/properties/parse-finn` with `{ url }`. Show inline spinner.
-- [ ] 5.2 On success: switch to the Manual tab with form values prefilled from the parsed data. Show a non-blocking info banner: `Hentet {N} felter fra FINN — sjekk og rediger ved behov.`
-- [ ] 5.3 On failure: show an inline error with the server's Norwegian message. The user can retry with a different URL or switch to Manual.
-- [ ] 5.4 On any user edit after prefill: keep the user's edit. Never re-trigger the parser unless the user explicitly clicks "Hent fra FINN" again.
+- [x] 5.1 On "Hent fra FINN" click: client POST to `/api/properties/parse-finn` with `{ url }`. Show inline spinner.
+- [x] 5.2 On success: switch to the Manual tab with form values prefilled from the parsed data. Show a non-blocking info banner: `Hentet {N} felter fra FINN — sjekk og rediger ved behov.`
+- [x] 5.3 On failure: show an inline error with the server's Norwegian message. The user can retry with a different URL or switch to Manual.
+- [x] 5.4 On any user edit after prefill: keep the user's edit. Never re-trigger the parser unless the user explicitly clicks "Hent fra FINN" again.
 
 ## 6. Tests
 

--- a/openspec/changes/properties-finn-import/tasks.md
+++ b/openspec/changes/properties-finn-import/tasks.md
@@ -17,12 +17,12 @@
 
 ## 3. Route Handler
 
-- [ ] 3.1 Create `src/app/api/properties/parse-finn/route.ts` exporting an async `POST` handler.
-- [ ] 3.2 Auth check via `createSupabaseServerClient()`; 401 if no session.
-- [ ] 3.3 Validate the URL via `validateFinnUrl`; 400 on bad input.
-- [ ] 3.4 Fetch the page via `fetchFinnHtml`; surface fetch errors with Norwegian messages.
-- [ ] 3.5 Parse via `parseFinnHtml`; build the `ParsedListing` response.
-- [ ] 3.6 Return JSON: `{ ok: true, data: ParsedListing }` or `{ ok: false, error: string }`. Never 500 on a parse problem — always a structured `ok: false`.
+- [x] 3.1 Create `src/app/api/properties/parse-finn/route.ts` exporting an async `POST` handler.
+- [x] 3.2 Auth check via `createSupabaseServerClient()`; 401 if no session.
+- [x] 3.3 Validate the URL via `validateFinnUrl`; 400 on bad input.
+- [x] 3.4 Fetch the page via `fetchFinnHtml`; surface fetch errors with Norwegian messages.
+- [x] 3.5 Parse via `parseFinnHtml`; build the `ParsedListing` response.
+- [x] 3.6 Return JSON: `{ ok: true, data: ParsedListing }` or `{ ok: false, error: string }`. Never 500 on a parse problem — always a structured `ok: false`.
 
 ## 4. UI — NyBoligForm tabs
 

--- a/openspec/changes/properties-finn-import/tasks.md
+++ b/openspec/changes/properties-finn-import/tasks.md
@@ -54,5 +54,5 @@
 
 ## 8. Operational
 
-- [ ] 8.1 Add `cheerio` to `package.json` (already in 1.1 — keep one source).
-- [ ] 8.2 Add a `// TODO(monitoring)` comment in the route handler noting where to add a Sentry/log call when parser extraction count drops below a threshold (e.g. < 3 fields). The actual instrumentation is deferred until we have a logging backend.
+- [x] 8.1 Add `cheerio` to `package.json` (already in 1.1 — keep one source).
+- [x] 8.2 Add a `// TODO(monitoring)` comment in the route handler noting where to add a Sentry/log call when parser extraction count drops below a threshold (e.g. < 3 fields). The actual instrumentation is deferred until we have a logging backend.

--- a/openspec/changes/properties/proposal.md
+++ b/openspec/changes/properties/proposal.md
@@ -28,7 +28,7 @@ In v1, adding a property means filling out a manual form. v2 keeps the manual fo
 
 ## Out of MVP scope (future changes)
 
-- **FINN-import**: paste FINN URL → server-side parse → prefill form. Requires Next.js API route or Supabase Edge Function. Will be a separate `properties-finn-import` change later.
+- ~~**FINN-import**: paste FINN URL → server-side parse → prefill form.~~ Shipped via the separate `properties-finn-import` capability — see `openspec/changes/properties-finn-import/`.
 - **Image upload**: per-property photo gallery via Supabase Storage. Will be a separate `properties-images` change. MVP shows a placeholder thumbnail.
 - **Property comments thread** (`Kommentarer` tab content): tab placeholder in MVP, full comments capability later.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@ducanh2912/next-pwa": "^10.2.9",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.45.4",
+        "cheerio": "^1.0.0",
         "next": "^14.2.15",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -4275,6 +4276,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -4474,6 +4480,46 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -4609,6 +4655,32 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -4778,6 +4850,57 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4822,6 +4945,18 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
@@ -4833,6 +4968,17 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -6035,12 +6181,52 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
       "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/idb": {
@@ -7123,6 +7309,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7325,6 +7522,51 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -8070,6 +8312,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -9136,6 +9383,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -9543,6 +9798,26 @@
       "peer": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@ducanh2912/next-pwa": "^10.2.9",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.45.4",
+    "cheerio": "^1.0.0",
     "next": "^14.2.15",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src/app/api/properties/parse-finn/route.test.ts
+++ b/src/app/api/properties/parse-finn/route.test.ts
@@ -1,0 +1,228 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Spec mapping:
+ *   - "FINN URL parsing" — happy path returns ok: true with the parsed data.
+ *   - "URL allowlist" — non-FINN URLs return ok: false / 400.
+ *   - "Authentication required" — unauthenticated returns 401.
+ *   - "Network failure" — fetch errors degrade to ok: false.
+ *
+ * The route handler imports `createSupabaseServerClient` and our fetch
+ * + parse helpers; we mock the Supabase factory and the fetch module
+ * to stage each scenario without spinning up a real server.
+ */
+
+// We mock these BEFORE importing the route, so that the route picks up
+// the mocked exports.
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn(),
+}));
+vi.mock("@/lib/finn/fetch", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/finn/fetch")>(
+    "@/lib/finn/fetch",
+  );
+  return {
+    ...actual,
+    fetchFinnHtml: vi.fn(),
+  };
+});
+
+import { fetchFinnHtml, FinnFetchError } from "@/lib/finn/fetch";
+import { FINN_ERROR_MESSAGES } from "@/lib/finn/types";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+import { POST } from "./route";
+
+function loadFixture(name: string): string {
+  return readFileSync(
+    resolve(__dirname, "../../../../../tests/fixtures/finn", name),
+    "utf8",
+  );
+}
+
+interface MockedSupabaseClient {
+  auth: {
+    getUser: () => Promise<{ data: { user: { id: string } | null } }>;
+  };
+}
+
+function makeAuthedClient(): MockedSupabaseClient {
+  return {
+    auth: {
+      getUser: async () => ({ data: { user: { id: "user-1" } } }),
+    },
+  };
+}
+
+function makeUnauthedClient(): MockedSupabaseClient {
+  return {
+    auth: {
+      getUser: async () => ({ data: { user: null } }),
+    },
+  };
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("https://test.local/api/properties/parse-finn", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/properties/parse-finn", () => {
+  const mockedSupabase = vi.mocked(createSupabaseServerClient);
+  const mockedFetch = vi.mocked(fetchFinnHtml);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns ok=true with the parsed data on the happy path", async () => {
+    mockedSupabase.mockReturnValue(
+      makeAuthedClient() as unknown as ReturnType<
+        typeof createSupabaseServerClient
+      >,
+    );
+    mockedFetch.mockResolvedValue(loadFixture("listing-1.html"));
+
+    const res = await POST(
+      makeRequest({
+        url: "https://www.finn.no/realestate/homes/ad.html?finnkode=1",
+      }) as Parameters<typeof POST>[0],
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.address).toBe("Storgata 1, 0182 Oslo");
+    expect(body.data.price).toBe(5_250_000);
+    expect(body.data.extracted_fields).toEqual(
+      expect.arrayContaining(["address", "price", "bra"]),
+    );
+  });
+
+  it("returns 401 when no Supabase session is present", async () => {
+    mockedSupabase.mockReturnValue(
+      makeUnauthedClient() as unknown as ReturnType<
+        typeof createSupabaseServerClient
+      >,
+    );
+
+    const res = await POST(
+      makeRequest({
+        url: "https://www.finn.no/realestate/homes/ad.html?finnkode=1",
+      }) as Parameters<typeof POST>[0],
+    );
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({
+      ok: false,
+      error: FINN_ERROR_MESSAGES.unauthenticated,
+    });
+    // No outbound fetch should have happened.
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 with notFinnUrl on a non-FINN host", async () => {
+    mockedSupabase.mockReturnValue(
+      makeAuthedClient() as unknown as ReturnType<
+        typeof createSupabaseServerClient
+      >,
+    );
+
+    const res = await POST(
+      makeRequest({ url: "https://example.com/anything" }) as Parameters<
+        typeof POST
+      >[0],
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({
+      ok: false,
+      error: FINN_ERROR_MESSAGES.notFinnUrl,
+    });
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on a malformed URL", async () => {
+    mockedSupabase.mockReturnValue(
+      makeAuthedClient() as unknown as ReturnType<
+        typeof createSupabaseServerClient
+      >,
+    );
+
+    const res = await POST(
+      makeRequest({ url: "not a url" }) as Parameters<typeof POST>[0],
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
+
+  it("returns 400 when url field is missing", async () => {
+    mockedSupabase.mockReturnValue(
+      makeAuthedClient() as unknown as ReturnType<
+        typeof createSupabaseServerClient
+      >,
+    );
+
+    const res = await POST(
+      makeRequest({}) as Parameters<typeof POST>[0],
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns ok=false (not 500) on fetch failure", async () => {
+    mockedSupabase.mockReturnValue(
+      makeAuthedClient() as unknown as ReturnType<
+        typeof createSupabaseServerClient
+      >,
+    );
+    mockedFetch.mockRejectedValue(
+      new FinnFetchError(FINN_ERROR_MESSAGES.fetchTimeout),
+    );
+
+    const res = await POST(
+      makeRequest({
+        url: "https://www.finn.no/realestate/homes/ad.html?finnkode=1",
+      }) as Parameters<typeof POST>[0],
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      ok: false,
+      error: FINN_ERROR_MESSAGES.fetchTimeout,
+    });
+  });
+
+  it("collapses unexpected throws to a controlled ok=false", async () => {
+    mockedSupabase.mockReturnValue(
+      makeAuthedClient() as unknown as ReturnType<
+        typeof createSupabaseServerClient
+      >,
+    );
+    mockedFetch.mockRejectedValue(new Error("kaboom"));
+
+    const res = await POST(
+      makeRequest({
+        url: "https://www.finn.no/realestate/homes/ad.html?finnkode=1",
+      }) as Parameters<typeof POST>[0],
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      ok: false,
+      error: FINN_ERROR_MESSAGES.unexpected,
+    });
+  });
+});

--- a/src/app/api/properties/parse-finn/route.ts
+++ b/src/app/api/properties/parse-finn/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { fetchFinnHtml, FinnFetchError } from "@/lib/finn/fetch";
+import { parseFinnHtml } from "@/lib/finn/parse";
+import { FINN_ERROR_MESSAGES, type ParseResult } from "@/lib/finn/types";
+import { validateFinnUrl } from "@/lib/finn/validateFinnUrl";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+/**
+ * `POST /api/properties/parse-finn`
+ *
+ * Body: `{ url: string }` — a public FINN listing URL.
+ * Response: structured `ParseResult` discriminated union — never throws
+ * an unhandled error. Status codes:
+ *   - 401: no Supabase session.
+ *   - 400: malformed body / non-FINN URL.
+ *   - 200: successful parse OR controlled fetch/parse failure
+ *     (`{ ok: false, error }`). The UI is structured-result-oriented;
+ *     the user-actionable failure paths all flow through the body, not
+ *     the HTTP status.
+ *
+ * TODO(monitoring): when we have a logging backend, instrument here:
+ * fire a metric/log when `extracted_fields.length < 3`, so we can spot
+ * FINN markup changes silently breaking the CSS fallback path before
+ * users complain.
+ *
+ * Spec mapping:
+ *   - "FINN URL parsing" — happy & partial paths land here.
+ *   - "URL allowlist" — D4 enforced via validateFinnUrl.
+ *   - "Authentication required" — D5 enforced via getUser.
+ *   - "Resource limits" — D6 enforced inside fetchFinnHtml.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  // Read the body defensively — a missing or non-JSON body shouldn't
+  // crash the route. Always return JSON.
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(FINN_ERROR_MESSAGES.malformedUrl, 400);
+  }
+
+  const url = isObject(body) ? body["url"] : undefined;
+  if (typeof url !== "string" || url.trim().length === 0) {
+    return jsonError(FINN_ERROR_MESSAGES.missingUrl, 400);
+  }
+
+  // Auth check (D5). 401 if no session.
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return jsonError(FINN_ERROR_MESSAGES.unauthenticated, 401);
+  }
+
+  // URL validation (D4). 400 on bad input.
+  const validation = validateFinnUrl(url);
+  if (!validation.ok) {
+    return jsonError(validation.error, 400);
+  }
+
+  // Fetch + parse. Both are wrapped — any unexpected throw degrades to
+  // a controlled `ok: false` so the UI never sees a 500.
+  try {
+    const html = await fetchFinnHtml(validation.url.toString());
+    const data = await parseFinnHtml(html, validation.url.toString());
+    const success: ParseResult = { ok: true, data };
+    return NextResponse.json(success, { status: 200 });
+  } catch (error) {
+    if (error instanceof FinnFetchError) {
+      return jsonError(error.userMessage, 200);
+    }
+    return jsonError(FINN_ERROR_MESSAGES.unexpected, 200);
+  }
+}
+
+function jsonError(message: string, status: number): NextResponse {
+  const body: ParseResult = { ok: false, error: message };
+  return NextResponse.json(body, { status });
+}
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}

--- a/src/components/properties/NyBoligForm.tsx
+++ b/src/components/properties/NyBoligForm.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 
 import { useActiveHousehold } from "@/components/households/ActiveHouseholdProvider";
+import type { ParsedListing, ParseResult } from "@/lib/finn/types";
+import { FINN_ERROR_MESSAGES } from "@/lib/finn/types";
 import type { PropertyStatus } from "@/lib/properties/types";
 import { EMPTY_ADDRESS_MESSAGE } from "@/lib/properties/types";
 import {
@@ -15,18 +17,75 @@ import {
 import { createProperty } from "@/server/properties/createProperty";
 
 /**
- * Single-page Ny bolig form. Sectioned per the design brief:
+ * Single-page Ny bolig form. Tab strip on top:
+ *   - Fra FINN-lenke (default per spec) — paste a URL, "Hent fra FINN"
+ *     POSTs to /api/properties/parse-finn, prefills the manual fields,
+ *     and switches to the Manual tab.
+ *   - Manuelt — the original sectioned form (unchanged behaviour).
+ *
+ * Sections:
  *   - Adresse & FINN-lenke
  *   - Prisinfo (totalpris, omkostninger, felleskostnader)
  *   - Størrelse (BRA, primærrom, soverom, bad)
  *   - Basis-fakta (byggeår, boligtype, etasje)
  *   - Status (dropdown — defaults to `vurderer`)
  *
- * D10 — the "Fra FINN-lenke" tab is intentionally hidden in MVP.
+ * The form is controlled (single `formValues` state) so the FINN parse
+ * can prefill arbitrary fields. Submit goes through `createProperty`
+ * exactly as before — D9 keeps the manual form as the source of truth.
  */
 interface NyBoligFormProps {
   statuses: PropertyStatus[];
 }
+
+type Tab = "finn" | "manual";
+
+interface FormValues {
+  address: string;
+  finn_link: string;
+  price: string;
+  costs: string;
+  monthly_costs: string;
+  bra: string;
+  primary_rooms: string;
+  bedrooms: string;
+  bathrooms: string;
+  year_built: string;
+  property_type: string;
+  floor: string;
+  status_id: string;
+  /** Set by the FINN parser — submitted unchanged unless cleared. */
+  image_url: string;
+}
+
+const EMPTY_VALUES: Omit<FormValues, "status_id"> = {
+  address: "",
+  finn_link: "",
+  price: "",
+  costs: "",
+  monthly_costs: "",
+  bra: "",
+  primary_rooms: "",
+  bedrooms: "",
+  bathrooms: "",
+  year_built: "",
+  property_type: "",
+  floor: "",
+  image_url: "",
+};
+
+/** Norwegian labels mirroring the ParsedListing keys, for the success notice. */
+const FIELD_LABELS_NO: Record<string, string> = {
+  address: "adresse",
+  price: "pris",
+  bra: "BRA",
+  primary_rooms: "primærrom",
+  bedrooms: "soverom",
+  bathrooms: "bad",
+  year_built: "byggeår",
+  property_type: "boligtype",
+  image_url: "bilde",
+};
 
 export function NyBoligForm({ statuses }: NyBoligFormProps) {
   const router = useRouter();
@@ -38,6 +97,106 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
   const defaultStatus =
     statuses.find((s) => s.label === "vurderer") ?? statuses[0];
 
+  const [tab, setTab] = useState<Tab>("finn");
+  const [values, setValues] = useState<FormValues>({
+    ...EMPTY_VALUES,
+    status_id: defaultStatus?.id ?? "",
+  });
+
+  // FINN tab state.
+  const [finnUrl, setFinnUrl] = useState<string>("");
+  const [finnError, setFinnError] = useState<string | null>(null);
+  const [finnLoading, setFinnLoading] = useState<boolean>(false);
+  const [prefillNotice, setPrefillNotice] = useState<string | null>(null);
+  const finnInputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus the FINN input when the FINN tab is active (spec
+  // "Default tab is FINN" — input should have focus on landing).
+  useEffect(() => {
+    if (tab === "finn") {
+      finnInputRef.current?.focus();
+    }
+  }, [tab]);
+
+  function setField<K extends keyof FormValues>(
+    key: K,
+    value: FormValues[K],
+  ): void {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function onFetchFinn(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setFinnError(null);
+    setPrefillNotice(null);
+
+    const url = finnUrl.trim();
+    if (!url) {
+      setFinnError(FINN_ERROR_MESSAGES.missingUrl);
+      return;
+    }
+
+    setFinnLoading(true);
+    let result: ParseResult | null = null;
+    try {
+      const res = await fetch("/api/properties/parse-finn", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url }),
+      });
+      result = (await res.json()) as ParseResult;
+    } catch {
+      setFinnLoading(false);
+      setFinnError(FINN_ERROR_MESSAGES.unexpected);
+      return;
+    }
+    setFinnLoading(false);
+
+    if (!result || !result.ok) {
+      setFinnError(result?.error ?? FINN_ERROR_MESSAGES.unexpected);
+      return;
+    }
+
+    applyParsedListing(result.data, url);
+  }
+
+  function applyParsedListing(parsed: ParsedListing, sourceUrl: string) {
+    setValues((prev) => ({
+      ...prev,
+      address: parsed.address ?? prev.address,
+      finn_link: sourceUrl,
+      price: parsed.price != null ? String(parsed.price) : prev.price,
+      bra: parsed.bra != null ? String(parsed.bra) : prev.bra,
+      primary_rooms:
+        parsed.primary_rooms != null
+          ? String(parsed.primary_rooms)
+          : prev.primary_rooms,
+      bedrooms:
+        parsed.bedrooms != null ? String(parsed.bedrooms) : prev.bedrooms,
+      bathrooms:
+        parsed.bathrooms != null
+          ? String(parsed.bathrooms)
+          : prev.bathrooms,
+      year_built:
+        parsed.year_built != null
+          ? String(parsed.year_built)
+          : prev.year_built,
+      property_type: parsed.property_type ?? prev.property_type,
+      image_url: parsed.image_url ?? prev.image_url,
+    }));
+
+    const labels = parsed.extracted_fields
+      .map((k) => FIELD_LABELS_NO[k] ?? k)
+      .join(", ");
+    const n = parsed.extracted_fields.length;
+    const notice =
+      n === 0
+        ? "Fant ingen felter på FINN-siden — fyll inn manuelt."
+        : `Hentet ${n} felter fra FINN — sjekk og rediger ved behov. (${labels})`;
+    setPrefillNotice(notice);
+    setTab("manual");
+  }
+
   function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError(null);
@@ -48,32 +207,29 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
       return;
     }
 
-    const fd = new FormData(e.currentTarget);
-    const address = String(fd.get("address") ?? "");
-    const v = validateAddress(address);
+    const v = validateAddress(values.address);
     if (!v.ok) {
       setAddressError(v.error);
       return;
     }
 
-    const yearBuilt = parseOptionalInt(fd.get("year_built"));
-
     startTransition(async () => {
       const r = await createProperty({
         householdId: activeHouseholdId,
         address: v.value,
-        finn_link: parseOptionalString(fd.get("finn_link")),
-        price: parseOptionalInt(fd.get("price")),
-        costs: parseOptionalInt(fd.get("costs")),
-        monthly_costs: parseOptionalInt(fd.get("monthly_costs")),
-        bra: parseOptionalNumber(fd.get("bra")),
-        primary_rooms: parseOptionalInt(fd.get("primary_rooms")),
-        bedrooms: parseOptionalInt(fd.get("bedrooms")),
-        bathrooms: parseOptionalNumber(fd.get("bathrooms")),
-        year_built: yearBuilt,
-        property_type: parseOptionalString(fd.get("property_type")),
-        floor: parseOptionalString(fd.get("floor")),
-        status_id: parseOptionalString(fd.get("status_id")),
+        finn_link: parseOptionalString(values.finn_link),
+        price: parseOptionalInt(values.price),
+        costs: parseOptionalInt(values.costs),
+        monthly_costs: parseOptionalInt(values.monthly_costs),
+        bra: parseOptionalNumber(values.bra),
+        primary_rooms: parseOptionalInt(values.primary_rooms),
+        bedrooms: parseOptionalInt(values.bedrooms),
+        bathrooms: parseOptionalNumber(values.bathrooms),
+        year_built: parseOptionalInt(values.year_built),
+        property_type: parseOptionalString(values.property_type),
+        floor: parseOptionalString(values.floor),
+        status_id: parseOptionalString(values.status_id),
+        image_url: parseOptionalString(values.image_url),
       });
       if (!r.ok) {
         setError(r.error);
@@ -85,7 +241,229 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
   }
 
   return (
+    <div className="space-y-6">
+      <Tabs tab={tab} onChange={setTab} />
+
+      {tab === "finn" ? (
+        <FinnTab
+          url={finnUrl}
+          onUrlChange={setFinnUrl}
+          onSubmit={onFetchFinn}
+          loading={finnLoading}
+          error={finnError}
+          onSwitchToManual={() => setTab("manual")}
+          inputRef={finnInputRef}
+        />
+      ) : (
+        <ManualTab
+          values={values}
+          onChange={setField}
+          statuses={statuses}
+          addressError={addressError}
+          submitError={error}
+          prefillNotice={prefillNotice}
+          onDismissNotice={() => setPrefillNotice(null)}
+          pending={pending}
+          onSubmit={onSubmit}
+          onCancel={() => router.push("/app")}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab strip
+// ---------------------------------------------------------------------------
+
+function Tabs({
+  tab,
+  onChange,
+}: {
+  tab: Tab;
+  onChange: (next: Tab) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Hvordan legge til bolig"
+      className="-mx-4 overflow-x-auto bg-surface-raised hide-scrollbar"
+    >
+      <ul className="flex min-w-max gap-6 px-4 sm:px-6">
+        <li>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "finn"}
+            onClick={() => onChange("finn")}
+            className={[
+              "inline-flex min-h-touch items-center whitespace-nowrap py-3 text-sm transition",
+              "border-b-2",
+              tab === "finn"
+                ? "border-primary font-bold text-primary"
+                : "border-transparent font-medium text-fg-muted hover:text-fg",
+            ].join(" ")}
+          >
+            Fra FINN-lenke
+          </button>
+        </li>
+        <li>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "manual"}
+            onClick={() => onChange("manual")}
+            className={[
+              "inline-flex min-h-touch items-center whitespace-nowrap py-3 text-sm transition",
+              "border-b-2",
+              tab === "manual"
+                ? "border-primary font-bold text-primary"
+                : "border-transparent font-medium text-fg-muted hover:text-fg",
+            ].join(" ")}
+          >
+            Manuelt
+          </button>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// FINN tab
+// ---------------------------------------------------------------------------
+
+function FinnTab({
+  url,
+  onUrlChange,
+  onSubmit,
+  loading,
+  error,
+  onSwitchToManual,
+  inputRef,
+}: {
+  url: string;
+  onUrlChange: (v: string) => void;
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  loading: boolean;
+  error: string | null;
+  onSwitchToManual: () => void;
+  inputRef: React.RefObject<HTMLInputElement>;
+}) {
+  return (
+    <form
+      onSubmit={onSubmit}
+      noValidate
+      className="space-y-4"
+      aria-labelledby="finn-tab-heading"
+    >
+      <section className="space-y-3 rounded-lg border border-border bg-surface p-4">
+        <h2
+          id="finn-tab-heading"
+          className="font-headline text-lg font-bold text-fg"
+        >
+          Lim inn FINN-lenke
+        </h2>
+        <p className="text-sm text-fg-muted">
+          Vi henter adresse, pris, størrelse og bilde automatisk. Du kan
+          rette på alt før du lagrer.
+        </p>
+        <div className="space-y-1">
+          <label htmlFor="ny-finn-url" className="block text-sm text-fg-muted">
+            FINN-lenke
+            <span aria-hidden className="ml-1 text-danger">
+              *
+            </span>
+            <span className="sr-only"> (påkrevd)</span>
+          </label>
+          <input
+            ref={inputRef}
+            id="ny-finn-url"
+            name="finn_url"
+            type="url"
+            required
+            value={url}
+            onChange={(e) => onUrlChange(e.target.value)}
+            placeholder="https://www.finn.no/realestate/homes/ad.html?finnkode=..."
+            disabled={loading}
+            aria-invalid={error ? "true" : "false"}
+            aria-describedby={error ? "finn-url-error" : undefined}
+            className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-60"
+          />
+          {error ? (
+            <p id="finn-url-error" role="alert" className="text-xs text-danger">
+              {error}
+            </p>
+          ) : null}
+        </div>
+      </section>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={onSwitchToManual}
+          className="text-sm font-medium text-primary underline decoration-dotted underline-offset-2 hover:text-primary-dim"
+        >
+          Eller fyll inn manuelt
+        </button>
+        <button
+          type="submit"
+          disabled={loading}
+          className="min-h-touch rounded-full bg-primary px-6 font-semibold text-primary-fg shadow-md transition hover:bg-primary-dim hover:shadow-lg disabled:opacity-60"
+        >
+          {loading ? "Henter…" : "Hent fra FINN"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Manual tab — controlled fields driven by `values`
+// ---------------------------------------------------------------------------
+
+function ManualTab({
+  values,
+  onChange,
+  statuses,
+  addressError,
+  submitError,
+  prefillNotice,
+  onDismissNotice,
+  pending,
+  onSubmit,
+  onCancel,
+}: {
+  values: FormValues;
+  onChange: <K extends keyof FormValues>(key: K, value: FormValues[K]) => void;
+  statuses: PropertyStatus[];
+  addressError: string | null;
+  submitError: string | null;
+  prefillNotice: string | null;
+  onDismissNotice: () => void;
+  pending: boolean;
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onCancel: () => void;
+}) {
+  return (
     <form onSubmit={onSubmit} noValidate className="space-y-6">
+      {prefillNotice ? (
+        <div
+          role="status"
+          className="flex items-start justify-between gap-3 rounded-md bg-surface-muted px-3 py-2 text-sm text-fg"
+        >
+          <span>{prefillNotice}</span>
+          <button
+            type="button"
+            onClick={onDismissNotice}
+            aria-label="Lukk melding"
+            className="text-fg-muted hover:text-fg"
+          >
+            ✕
+          </button>
+        </div>
+      ) : null}
+
       <Section title="Adresse & FINN-lenke">
         <Field label="Adresse" htmlFor="ny-address" required error={addressError}>
           <input
@@ -93,6 +471,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             name="address"
             type="text"
             required
+            value={values.address}
+            onChange={(e) => onChange("address", e.target.value)}
             aria-invalid={addressError ? "true" : "false"}
             aria-describedby={addressError ? "ny-address-error" : undefined}
             placeholder="Storgata 1, 0182 Oslo"
@@ -104,6 +484,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             id="ny-finn"
             name="finn_link"
             type="url"
+            value={values.finn_link}
+            onChange={(e) => onChange("finn_link", e.target.value)}
             placeholder="https://www.finn.no/realestate/homes/ad.html?finnkode=..."
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           />
@@ -118,6 +500,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             type="number"
             inputMode="numeric"
             min={0}
+            value={values.price}
+            onChange={(e) => onChange("price", e.target.value)}
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </Field>
@@ -128,6 +512,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             type="number"
             inputMode="numeric"
             min={0}
+            value={values.costs}
+            onChange={(e) => onChange("costs", e.target.value)}
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </Field>
@@ -138,6 +524,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             type="number"
             inputMode="numeric"
             min={0}
+            value={values.monthly_costs}
+            onChange={(e) => onChange("monthly_costs", e.target.value)}
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </Field>
@@ -152,6 +540,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             inputMode="decimal"
             min={0}
             step="0.1"
+            value={values.bra}
+            onChange={(e) => onChange("bra", e.target.value)}
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </Field>
@@ -162,6 +552,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             type="number"
             inputMode="numeric"
             min={0}
+            value={values.primary_rooms}
+            onChange={(e) => onChange("primary_rooms", e.target.value)}
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </Field>
@@ -172,6 +564,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             type="number"
             inputMode="numeric"
             min={0}
+            value={values.bedrooms}
+            onChange={(e) => onChange("bedrooms", e.target.value)}
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </Field>
@@ -183,6 +577,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             inputMode="decimal"
             min={0}
             step="0.5"
+            value={values.bathrooms}
+            onChange={(e) => onChange("bathrooms", e.target.value)}
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </Field>
@@ -196,6 +592,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             type="number"
             inputMode="numeric"
             min={1800}
+            value={values.year_built}
+            onChange={(e) => onChange("year_built", e.target.value)}
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </Field>
@@ -204,6 +602,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             id="ny-type"
             name="property_type"
             type="text"
+            value={values.property_type}
+            onChange={(e) => onChange("property_type", e.target.value)}
             placeholder="Leilighet, enebolig, …"
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           />
@@ -213,6 +613,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
             id="ny-floor"
             name="floor"
             type="text"
+            value={values.floor}
+            onChange={(e) => onChange("floor", e.target.value)}
             placeholder="2. etasje"
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           />
@@ -224,7 +626,8 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
           <select
             id="ny-status"
             name="status_id"
-            defaultValue={defaultStatus?.id ?? ""}
+            value={values.status_id}
+            onChange={(e) => onChange("status_id", e.target.value)}
             className="w-full min-h-touch rounded-lg bg-surface-muted px-4 text-fg shadow-sm placeholder:text-fg-soft focus:bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
           >
             {statuses.map((s) => (
@@ -236,19 +639,22 @@ export function NyBoligForm({ statuses }: NyBoligFormProps) {
         </Field>
       </Section>
 
-      {error ? (
+      {/* Hidden field — image_url comes from FINN, never user-edited here. */}
+      <input type="hidden" name="image_url" value={values.image_url} />
+
+      {submitError ? (
         <p
           role="alert"
           className="rounded-md bg-status-bud-inne px-3 py-2 text-sm text-status-bud-inne-fg"
         >
-          {error}
+          {submitError}
         </p>
       ) : null}
 
       <div className="flex flex-wrap justify-end gap-2">
         <button
           type="button"
-          onClick={() => router.push("/app")}
+          onClick={onCancel}
           disabled={pending}
           className="min-h-touch rounded-full px-5 text-fg hover:bg-surface-muted"
         >

--- a/src/lib/finn/fetch.test.ts
+++ b/src/lib/finn/fetch.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { FinnFetchError, fetchFinnHtml } from "./fetch";
+import { FINN_ERROR_MESSAGES } from "./types";
+
+/**
+ * Spec mapping:
+ *   - "Resource limits" — 5s timeout, 200KB cap.
+ *   - "Network failure" — 4xx/5xx surface as FinnFetchError, never throw
+ *     unhandled.
+ *
+ * We pass a custom `fetchImpl` rather than mocking the global so the
+ * tests are deterministic and Node-runtime independent.
+ */
+
+const URL = "https://www.finn.no/realestate/homes/ad.html?finnkode=1";
+
+function jsonResponse(body: string, init: ResponseInit = {}): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/html; charset=utf-8" },
+    ...init,
+  });
+}
+
+describe("fetchFinnHtml", () => {
+  it("returns the body on a 200 response", async () => {
+    const fetchImpl = async () => jsonResponse("<html><body>hi</body></html>");
+    const r = await fetchFinnHtml(URL, { fetchImpl: fetchImpl as typeof fetch });
+    expect(r).toContain("<body>hi</body>");
+  });
+
+  it("throws FinnFetchError on a 404", async () => {
+    const fetchImpl = async () =>
+      new Response("Not found", { status: 404 });
+    await expect(
+      fetchFinnHtml(URL, { fetchImpl: fetchImpl as typeof fetch }),
+    ).rejects.toMatchObject({
+      userMessage: FINN_ERROR_MESSAGES.fetchFailed,
+    });
+  });
+
+  it("throws FinnFetchError on a 5xx", async () => {
+    const fetchImpl = async () =>
+      new Response("oops", { status: 503 });
+    await expect(
+      fetchFinnHtml(URL, { fetchImpl: fetchImpl as typeof fetch }),
+    ).rejects.toBeInstanceOf(FinnFetchError);
+  });
+
+  it("translates AbortError to fetchTimeout", async () => {
+    const fetchImpl = async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      // Simulate the runtime behaviour: when the abort signal fires, the
+      // fetch implementation rejects with an AbortError.
+      return await new Promise<Response>((_, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    };
+    await expect(
+      fetchFinnHtml(URL, { fetchImpl: fetchImpl as typeof fetch }),
+    ).rejects.toMatchObject({
+      userMessage: FINN_ERROR_MESSAGES.fetchTimeout,
+    });
+  }, 10_000);
+
+  it("rejects responses larger than 200KB up-front via content-length", async () => {
+    const fetchImpl = async () =>
+      new Response("x".repeat(10), {
+        status: 200,
+        headers: {
+          "content-type": "text/html",
+          "content-length": String(300 * 1024),
+        },
+      });
+    await expect(
+      fetchFinnHtml(URL, { fetchImpl: fetchImpl as typeof fetch }),
+    ).rejects.toMatchObject({
+      userMessage: FINN_ERROR_MESSAGES.responseTooLarge,
+    });
+  });
+
+  it("rejects oversized streaming bodies even when content-length is missing", async () => {
+    // 300KB of payload, no content-length advertised.
+    const big = "x".repeat(300 * 1024);
+    const fetchImpl = async () =>
+      new Response(big, {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      });
+    await expect(
+      fetchFinnHtml(URL, { fetchImpl: fetchImpl as typeof fetch }),
+    ).rejects.toMatchObject({
+      userMessage: FINN_ERROR_MESSAGES.responseTooLarge,
+    });
+  });
+});

--- a/src/lib/finn/fetch.ts
+++ b/src/lib/finn/fetch.ts
@@ -1,0 +1,133 @@
+import { FINN_ERROR_MESSAGES, type FinnErrorMessage } from "./types";
+
+/** 5-second timeout on the upstream fetch (D6). */
+const FETCH_TIMEOUT_MS = 5_000;
+
+/** 200 KB body cap (D6). Anything larger is treated as malicious / wrong. */
+const MAX_BODY_BYTES = 200 * 1024;
+
+/**
+ * Polite User-Agent (D7). Identifies us so FINN can rate-limit / contact
+ * us instead of silently blocking. Bump the version when behaviour
+ * changes meaningfully.
+ */
+const USER_AGENT = "Boligscore/1.0 (+https://boligscore.app)";
+
+/**
+ * Tagged error subclass so the route handler can distinguish the
+ * controlled error categories (timeout / oversized / non-2xx) from
+ * unexpected throws and translate to the right Norwegian message.
+ */
+export class FinnFetchError extends Error {
+  readonly userMessage: FinnErrorMessage;
+
+  constructor(userMessage: FinnErrorMessage, cause?: unknown) {
+    super(userMessage);
+    this.name = "FinnFetchError";
+    this.userMessage = userMessage;
+    if (cause !== undefined) {
+      // Best-effort `cause` propagation (Node 16.9+ supports the option).
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+/**
+ * Fetch a FINN listing as text, enforcing the timeout + body cap.
+ *
+ * The caller is expected to have already validated the URL via
+ * `validateFinnUrl`. We don't re-check the host here because the route
+ * handler should never call this with an unvalidated URL — keeping
+ * concerns separate makes both functions easier to test in isolation.
+ */
+export async function fetchFinnHtml(
+  url: string,
+  options: { fetchImpl?: typeof fetch } = {},
+): Promise<string> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "GET",
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "nb-NO,nb;q=0.9,no;q=0.8,en;q=0.5",
+      },
+      signal: controller.signal,
+      // Don't follow redirects to a non-FINN host. Default `redirect:
+      // 'follow'` is fine here — FINN's redirects stay on finn.no.
+      redirect: "follow",
+    });
+  } catch (cause) {
+    clearTimeout(timeoutId);
+    if (cause instanceof Error && cause.name === "AbortError") {
+      throw new FinnFetchError(FINN_ERROR_MESSAGES.fetchTimeout, cause);
+    }
+    throw new FinnFetchError(FINN_ERROR_MESSAGES.fetchFailed, cause);
+  }
+  clearTimeout(timeoutId);
+
+  if (!response.ok) {
+    throw new FinnFetchError(FINN_ERROR_MESSAGES.fetchFailed);
+  }
+
+  // Stream + cap the body. We avoid `response.text()` (no built-in cap)
+  // and instead read chunks until we either hit the cap or finish.
+  const text = await readBodyCapped(response, MAX_BODY_BYTES);
+  return text;
+}
+
+/**
+ * Read a Response body up to `maxBytes`. Throws `FinnFetchError` if the
+ * body exceeds the cap — we always want a controlled error instead of a
+ * generic "out of memory" / silently-truncated string.
+ */
+async function readBodyCapped(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new FinnFetchError(FINN_ERROR_MESSAGES.responseTooLarge);
+  }
+
+  // Prefer the stream API so we can bail early. Fall back to text() on
+  // runtimes where body is null (some test fakes).
+  if (!response.body) {
+    const fallback = await response.text();
+    if (Buffer.byteLength(fallback, "utf8") > maxBytes) {
+      throw new FinnFetchError(FINN_ERROR_MESSAGES.responseTooLarge);
+    }
+    return fallback;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let received = 0;
+  let html = "";
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > maxBytes) {
+        throw new FinnFetchError(FINN_ERROR_MESSAGES.responseTooLarge);
+      }
+      html += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // releaseLock can throw on some runtimes when the stream is
+      // already errored — we don't care, we're already on an error path.
+    }
+  }
+  html += decoder.decode();
+  return html;
+}

--- a/src/lib/finn/parse.test.ts
+++ b/src/lib/finn/parse.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { parseFinnHtml } from "./parse";
+
+/**
+ * Spec mapping (openspec/changes/properties-finn-import/specs/properties-finn-import/spec.md):
+ *   - "FINN URL parsing" — successful, partial, and never-throws paths.
+ *
+ * Fixtures live in `tests/fixtures/finn/` (D10). They are SYNTHETIC at
+ * the time of writing — modeled after FINN's published markup but not
+ * captured from a real listing. Replace with anonymized real captures
+ * when available; the test assertions should still hold because they
+ * target schema.org / common label patterns.
+ */
+function loadFixture(name: string): string {
+  return readFileSync(
+    resolve(__dirname, "../../../tests/fixtures/finn", name),
+    "utf8",
+  );
+}
+
+const FAKE_URL = "https://www.finn.no/realestate/homes/ad.html?finnkode=1";
+
+describe("parseFinnHtml — JSON-LD extraction", () => {
+  it("extracts every field from a well-formed JSON-LD block", async () => {
+    const html = loadFixture("listing-1.html");
+    const r = await parseFinnHtml(html, FAKE_URL);
+
+    expect(r.address).toBe("Storgata 1, 0182 Oslo");
+    expect(r.price).toBe(5_250_000);
+    expect(r.bra).toBe(72.5);
+    expect(r.bedrooms).toBe(2);
+    expect(r.primary_rooms).toBe(3);
+    expect(r.year_built).toBe(1932);
+    expect(r.property_type).toBe("Leilighet");
+    expect(r.image_url).toBe(
+      "https://images.finncdn.no/dynamic/example/listing-1.jpg",
+    );
+    expect(r.finn_link).toBe(FAKE_URL);
+  });
+
+  it("populates extracted_fields with every successfully-set key", async () => {
+    const html = loadFixture("listing-1.html");
+    const r = await parseFinnHtml(html, FAKE_URL);
+
+    expect(r.extracted_fields).toEqual(
+      expect.arrayContaining([
+        "address",
+        "price",
+        "bra",
+        "primary_rooms",
+        "bedrooms",
+        "year_built",
+        "property_type",
+        "image_url",
+      ]),
+    );
+  });
+
+  it("ignores non-listing JSON-LD blocks (BreadcrumbList, etc.)", async () => {
+    // listing-1.html includes a BreadcrumbList block — the parser must
+    // pick the Product block, not crash on the second one.
+    const html = loadFixture("listing-1.html");
+    const r = await parseFinnHtml(html, FAKE_URL);
+    expect(r.address).not.toBeNull();
+  });
+});
+
+describe("parseFinnHtml — CSS-selector fallback", () => {
+  it("extracts fields from labelled tables when JSON-LD is missing", async () => {
+    const html = loadFixture("listing-2.html");
+    const r = await parseFinnHtml(html, FAKE_URL);
+
+    expect(r.address).toBe("Bjørkeveien 12, 7010 Trondheim");
+    expect(r.price).toBe(3_950_000);
+    expect(r.bra).toBe(120);
+    expect(r.primary_rooms).toBe(110);
+    expect(r.bedrooms).toBe(4);
+    expect(r.bathrooms).toBe(2);
+    expect(r.year_built).toBe(1985);
+    expect(r.property_type).toBe("Enebolig");
+    expect(r.image_url).toBe(
+      "https://images.finncdn.no/dynamic/example/listing-2.jpg",
+    );
+  });
+});
+
+describe("parseFinnHtml — partial extraction", () => {
+  it("returns nulls for missing fields and never throws", async () => {
+    const html = loadFixture("listing-3-partial.html");
+    const r = await parseFinnHtml(html, FAKE_URL);
+
+    expect(r.address).toBe("Sjøgata 4, 8006 Bodø");
+    expect(r.image_url).toBe(
+      "https://images.finncdn.no/dynamic/example/listing-3.jpg",
+    );
+    expect(r.price).toBeNull();
+    expect(r.bra).toBeNull();
+    expect(r.year_built).toBeNull();
+    expect(r.bedrooms).toBeNull();
+    expect(r.bathrooms).toBeNull();
+    expect(r.primary_rooms).toBeNull();
+    expect(r.property_type).toBeNull();
+    expect(r.extracted_fields).toEqual(
+      expect.arrayContaining(["address", "image_url"]),
+    );
+  });
+});
+
+describe("parseFinnHtml — robustness", () => {
+  it("does not throw on garbage input", async () => {
+    const r = await parseFinnHtml("not really html", FAKE_URL);
+    expect(r.finn_link).toBe(FAKE_URL);
+    expect(r.extracted_fields).toEqual([]);
+  });
+
+  it("does not throw on malformed JSON-LD", async () => {
+    const html = `
+      <html><body>
+        <script type="application/ld+json">{ this is not valid json }</script>
+        <h1>Storgata 1, 0182 Oslo</h1>
+      </body></html>
+    `;
+    const r = await parseFinnHtml(html, FAKE_URL);
+    expect(r.address).toBe("Storgata 1, 0182 Oslo");
+  });
+
+  it("handles empty html", async () => {
+    const r = await parseFinnHtml("", FAKE_URL);
+    expect(r.extracted_fields).toEqual([]);
+    expect(r.finn_link).toBe(FAKE_URL);
+  });
+});

--- a/src/lib/finn/parse.ts
+++ b/src/lib/finn/parse.ts
@@ -1,0 +1,435 @@
+import * as cheerio from "cheerio";
+
+import type { ParsedListing, ParsedListingKey } from "./types";
+
+/**
+ * Parse a FINN listing HTML string into a partial `ParsedListing`.
+ *
+ * Strategy (D1, "JSON-LD-first"):
+ *   1. Look for any `<script type="application/ld+json">` blocks. Walk
+ *      every contained object (top-level, `@graph`-nested, arrays of
+ *      objects) and pick the first whose `@type` matches our candidate
+ *      list (Product, Place, Residence, RealEstateListing, …). FINN
+ *      historically uses `Product` for ad pages.
+ *   2. For fields the JSON-LD didn't fill in, fall back to CSS selectors
+ *      on the rendered HTML. These selectors are brittle (FINN renames
+ *      classes regularly) — every selector tries multiple strategies and
+ *      gracefully returns null on a miss.
+ *   3. NEVER throw. A parse error on one field must not abort the rest.
+ *      `extracted_fields` reflects what we actually populated.
+ *
+ * The function is async to keep room for future extensions (e.g.
+ * fetching nested resources). Today it is synchronous internally.
+ */
+export async function parseFinnHtml(
+  html: string,
+  finnLink: string,
+): Promise<ParsedListing> {
+  const $ = cheerio.load(html);
+  const fromJsonLd = extractFromJsonLd($);
+  const merged: Omit<ParsedListing, "extracted_fields" | "finn_link"> = {
+    address: fromJsonLd.address ?? extractAddress($),
+    price: fromJsonLd.price ?? extractPrice($),
+    bra: fromJsonLd.bra ?? extractBra($),
+    primary_rooms: fromJsonLd.primary_rooms ?? extractPrimaryRooms($),
+    bedrooms: fromJsonLd.bedrooms ?? extractBedrooms($),
+    bathrooms: fromJsonLd.bathrooms ?? extractBathrooms($),
+    year_built: fromJsonLd.year_built ?? extractYearBuilt($),
+    property_type: fromJsonLd.property_type ?? extractPropertyType($),
+    image_url: fromJsonLd.image_url ?? extractImageUrl($),
+  };
+
+  const extracted_fields = (
+    Object.keys(merged) as ParsedListingKey[]
+  ).filter((k) => merged[k] !== null && merged[k] !== undefined);
+
+  return {
+    ...merged,
+    finn_link: finnLink,
+    extracted_fields,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// JSON-LD extraction
+// ---------------------------------------------------------------------------
+
+/** `@type` values we treat as candidate listings. FINN uses `Product`. */
+const CANDIDATE_TYPES = new Set<string>([
+  "Product",
+  "Place",
+  "Residence",
+  "RealEstateListing",
+  "Apartment",
+  "House",
+  "SingleFamilyResidence",
+  "Accommodation",
+]);
+
+/**
+ * Walk every JSON-LD block, flatten `@graph` arrays, return the first
+ * object whose `@type` matches a candidate. We also keep going even
+ * when one block parses to nonsense — FINN sometimes ships multiple
+ * blocks (Organization, BreadcrumbList, etc.).
+ */
+function extractFromJsonLd($: cheerio.CheerioAPI): Partial<
+  Omit<ParsedListing, "extracted_fields" | "finn_link">
+> {
+  const result: Partial<Omit<ParsedListing, "extracted_fields" | "finn_link">> = {};
+
+  $('script[type="application/ld+json"]').each((_, el) => {
+    const raw = $(el).contents().text();
+    if (!raw) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      // Some sites embed multiple JSON objects in one script — ignore
+      // and move on.
+      return;
+    }
+
+    for (const node of flattenJsonLd(parsed)) {
+      if (!isObject(node)) continue;
+      const type = node["@type"];
+      const types = Array.isArray(type) ? type : [type];
+      const match = types.some(
+        (t) => typeof t === "string" && CANDIDATE_TYPES.has(t),
+      );
+      if (!match) continue;
+
+      mergeFromJsonLdNode(node, result);
+    }
+  });
+
+  return result;
+}
+
+function* flattenJsonLd(input: unknown): Iterable<unknown> {
+  if (input == null) return;
+  if (Array.isArray(input)) {
+    for (const item of input) yield* flattenJsonLd(item);
+    return;
+  }
+  if (isObject(input)) {
+    yield input;
+    const graph = input["@graph"];
+    if (Array.isArray(graph)) {
+      for (const item of graph) yield* flattenJsonLd(item);
+    }
+  }
+}
+
+function mergeFromJsonLdNode(
+  node: Record<string, unknown>,
+  out: Partial<Omit<ParsedListing, "extracted_fields" | "finn_link">>,
+): void {
+  // address — `address.streetAddress` or top-level `name` (which on FINN
+  // is often the address itself)
+  if (out.address == null) {
+    const addr = node["address"];
+    if (isObject(addr)) {
+      const street = pickString(addr, ["streetAddress"]);
+      const postalCode = pickString(addr, ["postalCode"]);
+      const locality = pickString(addr, [
+        "addressLocality",
+        "addressRegion",
+      ]);
+      const composed = [street, [postalCode, locality].filter(Boolean).join(" ")]
+        .filter((s): s is string => Boolean(s && s.trim()))
+        .join(", ");
+      if (composed) out.address = composed;
+    }
+    if (out.address == null) {
+      const name = pickString(node, ["name"]);
+      if (name) out.address = name;
+    }
+  }
+
+  // price — `offers.price`, `offers.priceSpecification.price`
+  if (out.price == null) {
+    const offers = node["offers"];
+    const offerNodes = Array.isArray(offers)
+      ? offers
+      : isObject(offers)
+        ? [offers]
+        : [];
+    for (const offer of offerNodes) {
+      if (!isObject(offer)) continue;
+      const direct = coerceNumber(offer["price"]);
+      if (direct != null) {
+        out.price = direct;
+        break;
+      }
+      const spec = offer["priceSpecification"];
+      if (isObject(spec)) {
+        const specPrice = coerceNumber(spec["price"]);
+        if (specPrice != null) {
+          out.price = specPrice;
+          break;
+        }
+      }
+    }
+  }
+
+  // BRA / floorSize
+  if (out.bra == null) {
+    const floorSize = node["floorSize"];
+    if (isObject(floorSize)) {
+      const value = coerceNumber(floorSize["value"]);
+      if (value != null) out.bra = value;
+    } else {
+      const direct = coerceNumber(floorSize);
+      if (direct != null) out.bra = direct;
+    }
+  }
+
+  // numberOfBedrooms — sometimes on Apartment/House nodes
+  if (out.bedrooms == null) {
+    const bedrooms = coerceInt(node["numberOfBedrooms"]);
+    if (bedrooms != null) out.bedrooms = bedrooms;
+  }
+  if (out.bathrooms == null) {
+    const baths = coerceNumber(node["numberOfBathroomsTotal"] ?? node["numberOfBathrooms"]);
+    if (baths != null) out.bathrooms = baths;
+  }
+  if (out.primary_rooms == null) {
+    const rooms = coerceNumber(node["numberOfRooms"]);
+    if (rooms != null) out.primary_rooms = rooms;
+  }
+
+  // image — string or array of strings/objects
+  if (out.image_url == null) {
+    const image = node["image"];
+    const candidate = pickImageUrl(image);
+    if (candidate) out.image_url = candidate;
+  }
+
+  // year built — yearBuilt / dateCreated (fall back to 4-digit text)
+  if (out.year_built == null) {
+    const yb = coerceInt(node["yearBuilt"]);
+    if (yb != null) out.year_built = yb;
+  }
+
+  // property_type — `category` or `@type` itself when the node is e.g.
+  // `Apartment`. Keep the JSON-LD value verbatim so the manual form
+  // surfaces what FINN classified it as.
+  if (out.property_type == null) {
+    const category = pickString(node, ["category"]);
+    if (category) out.property_type = category;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CSS-selector fallbacks
+// ---------------------------------------------------------------------------
+//
+// These selectors are intentionally conservative — they look for common
+// label patterns ("BRA", "Byggeår", …) rather than depending on stable
+// class names. They will degrade when FINN changes copy, but that's a
+// less frequent event than CSS refactors.
+
+function extractAddress($: cheerio.CheerioAPI): string | null {
+  // FINN typically renders the address as the page H1. We accept any
+  // first-level heading whose text contains a digit (a postal code or
+  // street number) to filter out generic labels like "Bolig til salgs".
+  const candidates = $("h1");
+  for (const el of candidates.toArray()) {
+    const text = $(el).text().trim();
+    if (text.length > 5 && text.length < 200 && /\d/.test(text)) {
+      return text;
+    }
+  }
+  return null;
+}
+
+function extractPrice($: cheerio.CheerioAPI): number | null {
+  // Try an explicit price label first.
+  const labelled = findLabelledValue($, [
+    "Prisantydning",
+    "Totalpris",
+    "Pris",
+  ]);
+  if (labelled) {
+    const parsed = parseNorwegianInt(labelled);
+    if (parsed != null) return parsed;
+  }
+  // Fall back to any element containing "kr" + digits.
+  const krMatch = $("body")
+    .text()
+    .match(/(\d[\d\s\u00A0]{2,})\s*(?:kr|NOK|,-)/);
+  if (krMatch) {
+    const parsed = parseNorwegianInt(krMatch[1]!);
+    if (parsed != null) return parsed;
+  }
+  return null;
+}
+
+function extractBra($: cheerio.CheerioAPI): number | null {
+  const v = findLabelledValue($, [
+    "Bruksareal",
+    "BRA",
+    "Bruksareal (BRA)",
+    "Internt bruksareal",
+  ]);
+  if (!v) return null;
+  return parseSquareMeters(v);
+}
+
+function extractPrimaryRooms($: cheerio.CheerioAPI): number | null {
+  const v = findLabelledValue($, ["Primærrom", "P-rom"]);
+  if (!v) return null;
+  return parseSquareMeters(v);
+}
+
+function extractBedrooms($: cheerio.CheerioAPI): number | null {
+  const v = findLabelledValue($, ["Soverom"]);
+  if (!v) return null;
+  const n = parseInt(v.replace(/[^\d]/g, ""), 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function extractBathrooms($: cheerio.CheerioAPI): number | null {
+  const v = findLabelledValue($, ["Bad", "Bad/wc"]);
+  if (!v) return null;
+  const n = Number(v.replace(/[^\d.,]/g, "").replace(",", "."));
+  return Number.isFinite(n) ? n : null;
+}
+
+function extractYearBuilt($: cheerio.CheerioAPI): number | null {
+  const v = findLabelledValue($, ["Byggeår"]);
+  if (!v) return null;
+  const m = v.match(/(\d{4})/);
+  if (!m) return null;
+  const year = Number(m[1]);
+  if (!Number.isFinite(year) || year < 1500 || year > 2100) return null;
+  return year;
+}
+
+function extractPropertyType($: cheerio.CheerioAPI): string | null {
+  const v = findLabelledValue($, ["Boligtype"]);
+  return v ? v.trim() : null;
+}
+
+function extractImageUrl($: cheerio.CheerioAPI): string | null {
+  // Prefer Open Graph — it's what FINN sets for share previews.
+  const og = $('meta[property="og:image"]').attr("content");
+  if (og && og.startsWith("https://")) return og;
+  // First gallery image, fallback.
+  const firstImg = $('img[src^="https://"]').first().attr("src");
+  return firstImg ?? null;
+}
+
+/**
+ * Find a `<dl>` label or a generic "label cell + value cell" pair where
+ * the label text matches one of `labels` (case-insensitive). Returns
+ * the trimmed value text, or null.
+ */
+function findLabelledValue(
+  $: cheerio.CheerioAPI,
+  labels: string[],
+): string | null {
+  const wanted = labels.map((l) => l.toLowerCase());
+
+  // <dl><dt>label</dt><dd>value</dd></dl>
+  const dts = $("dt");
+  for (const el of dts.toArray()) {
+    const text = $(el).text().trim().toLowerCase();
+    if (wanted.includes(text)) {
+      const dd = $(el).next("dd");
+      if (dd.length) return dd.text().trim();
+    }
+  }
+
+  // generic table-row pattern: <th>label</th><td>value</td>
+  const ths = $("th");
+  for (const el of ths.toArray()) {
+    const text = $(el).text().trim().toLowerCase();
+    if (wanted.includes(text)) {
+      const td = $(el).next("td");
+      if (td.length) return td.text().trim();
+    }
+  }
+
+  // generic "label" + "value" sibling spans / divs.
+  const allLabelled = $('[data-testid], [class*="label"], [class*="Label"]');
+  for (const el of allLabelled.toArray()) {
+    const text = $(el).text().trim().toLowerCase();
+    if (!wanted.includes(text)) continue;
+    const next = $(el).next();
+    if (next.length) {
+      const v = next.text().trim();
+      if (v) return v;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Number coercion helpers
+// ---------------------------------------------------------------------------
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function pickString(
+  obj: Record<string, unknown>,
+  keys: string[],
+): string | null {
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === "string" && v.trim().length > 0) return v.trim();
+  }
+  return null;
+}
+
+function pickImageUrl(value: unknown): string | null {
+  if (typeof value === "string" && value.startsWith("http")) return value;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = pickImageUrl(item);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (isObject(value)) {
+    const direct = pickString(value, ["url", "contentUrl"]);
+    if (direct) return direct;
+  }
+  return null;
+}
+
+function coerceNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^\d.,-]/g, "").replace(/\s/g, "");
+    if (!cleaned) return null;
+    const n = Number(cleaned.replace(",", "."));
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function coerceInt(value: unknown): number | null {
+  const n = coerceNumber(value);
+  return n == null ? null : Math.trunc(n);
+}
+
+/** Parse a Norwegian-formatted integer ("4 250 000", "4.250.000"). */
+function parseNorwegianInt(input: string): number | null {
+  const cleaned = input.replace(/[^\d]/g, "");
+  if (!cleaned) return null;
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Parse a "70 m²" / "70,5 m²" string to a number. */
+function parseSquareMeters(input: string): number | null {
+  const m = input.match(/([\d.,\s\u00A0]+)/);
+  if (!m) return null;
+  const cleaned = m[1]!.replace(/\s|\u00A0/g, "").replace(",", ".");
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/lib/finn/types.ts
+++ b/src/lib/finn/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared types for the FINN parser pipeline.
+ *
+ * `ParsedListing` is the structured-but-partial result of parsing a FINN
+ * listing page. Every field is optional (null) — the parser is allowed
+ * to surface a 30%-extracted listing instead of failing the whole call.
+ *
+ * `ParseResult` is the discriminated union the route handler returns to
+ * the client. The success variant always carries the partial listing
+ * with an `extracted_fields` array reflecting what was actually found.
+ */
+
+/** Fields the parser tries to populate from a FINN listing. */
+export interface ParsedListing {
+  address: string | null;
+  price: number | null;
+  /** Bruksareal (m²) — `floorSize` in JSON-LD or "BRA" label fallback. */
+  bra: number | null;
+  /** Primærrom (m²). */
+  primary_rooms: number | null;
+  bedrooms: number | null;
+  bathrooms: number | null;
+  year_built: number | null;
+  property_type: string | null;
+  image_url: string | null;
+  /** The original FINN URL — echoed back so the client doesn't re-derive. */
+  finn_link: string;
+  /**
+   * Names of keys (excluding `finn_link` and `extracted_fields`) that the
+   * parser successfully populated. Mirrors the spec's "Successful parse"
+   * scenario.
+   */
+  extracted_fields: ParsedListingKey[];
+}
+
+export type ParsedListingKey =
+  | "address"
+  | "price"
+  | "bra"
+  | "primary_rooms"
+  | "bedrooms"
+  | "bathrooms"
+  | "year_built"
+  | "property_type"
+  | "image_url";
+
+/** Discriminated union returned by the route handler. */
+export type ParseResult =
+  | { ok: true; data: ParsedListing }
+  | { ok: false; error: string };
+
+/** Result of `validateFinnUrl` — a tiny pre-fetch validator. */
+export type FinnUrlValidation =
+  | { ok: true; url: URL }
+  | { ok: false; error: string };
+
+/** User-facing Norwegian error messages used by the route handler. */
+export const FINN_ERROR_MESSAGES = {
+  /** Invalid / non-FINN host — surfaces as 400. */
+  notFinnUrl: "URL må være en FINN-annonse",
+  /** Malformed URL string. */
+  malformedUrl: "Ugyldig URL",
+  /** Empty body / no URL field. */
+  missingUrl: "URL mangler",
+  /** Auth missing — surfaces as 401. */
+  unauthenticated: "Du må være logget inn",
+  /** Upstream timeout. */
+  fetchTimeout:
+    "FINN svarer ikke — prøv igjen senere eller fyll inn manuelt",
+  /** Upstream non-2xx (4xx, 5xx). */
+  fetchFailed:
+    "Kunne ikke hente fra FINN — prøv igjen senere eller fyll inn manuelt",
+  /** Body exceeded 200 KB cap. */
+  responseTooLarge:
+    "FINN-siden er for stor — prøv en annen lenke eller fyll inn manuelt",
+  /** Generic fallback. */
+  unexpected:
+    "Uventet feil ved henting fra FINN — fyll inn manuelt",
+} as const;
+
+export type FinnErrorMessage =
+  (typeof FINN_ERROR_MESSAGES)[keyof typeof FINN_ERROR_MESSAGES];

--- a/src/lib/finn/validateFinnUrl.test.ts
+++ b/src/lib/finn/validateFinnUrl.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { FINN_ERROR_MESSAGES } from "./types";
+import { validateFinnUrl } from "./validateFinnUrl";
+
+/**
+ * Spec mapping (openspec/changes/properties-finn-import/specs/properties-finn-import/spec.md):
+ *   - "URL allowlist" — non-FINN host rejected, malformed URL rejected,
+ *     both `finn.no` and `www.finn.no` accepted.
+ *
+ * Decision matrix this exercise covers:
+ *   ┌──────────────────────┬─────────┐
+ *   │ input                 │ result  │
+ *   ├──────────────────────┼─────────┤
+ *   │ valid www.finn.no    │ ok      │
+ *   │ valid finn.no        │ ok      │
+ *   │ subdomain.finn.no    │ reject  │
+ *   │ http (not https)     │ reject  │
+ *   │ other host           │ reject  │
+ *   │ malformed string     │ reject  │
+ *   │ empty / whitespace   │ reject  │
+ *   │ non-string           │ reject  │
+ *   └──────────────────────┴─────────┘
+ */
+
+describe("validateFinnUrl", () => {
+  it("accepts a real FINN listing URL on www.finn.no", () => {
+    const r = validateFinnUrl(
+      "https://www.finn.no/realestate/homes/ad.html?finnkode=123456789",
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.url.hostname).toBe("www.finn.no");
+  });
+
+  it("accepts the bare finn.no apex domain", () => {
+    const r = validateFinnUrl("https://finn.no/realestate/homes/ad.html");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.url.hostname).toBe("finn.no");
+  });
+
+  it("rejects subdomains other than www", () => {
+    const r = validateFinnUrl("https://m.finn.no/realestate/homes/ad.html");
+    expect(r).toEqual({ ok: false, error: FINN_ERROR_MESSAGES.notFinnUrl });
+  });
+
+  it("rejects http:// (only https is allowed)", () => {
+    const r = validateFinnUrl("http://www.finn.no/realestate/homes/ad.html");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe(FINN_ERROR_MESSAGES.notFinnUrl);
+  });
+
+  it("rejects unrelated hosts with the same path", () => {
+    const r = validateFinnUrl(
+      "https://example.com/realestate/homes/ad.html?finnkode=123",
+    );
+    expect(r).toEqual({ ok: false, error: FINN_ERROR_MESSAGES.notFinnUrl });
+  });
+
+  it("rejects look-alike domains (typosquatting / suffix tricks)", () => {
+    expect(validateFinnUrl("https://finn.no.example.com/abc")).toMatchObject({
+      ok: false,
+    });
+    expect(validateFinnUrl("https://finn-no.com/abc")).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(validateFinnUrl("not a url")).toMatchObject({ ok: false });
+    expect(validateFinnUrl("htt p:/broken")).toMatchObject({ ok: false });
+    expect(validateFinnUrl("javascript:alert(1)")).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("rejects empty / whitespace input", () => {
+    expect(validateFinnUrl("")).toMatchObject({ ok: false });
+    expect(validateFinnUrl("   ")).toMatchObject({ ok: false });
+    expect(validateFinnUrl("\t\n")).toMatchObject({ ok: false });
+  });
+
+  it("rejects non-string input", () => {
+    expect(validateFinnUrl(undefined)).toMatchObject({ ok: false });
+    expect(validateFinnUrl(null)).toMatchObject({ ok: false });
+    expect(validateFinnUrl(42)).toMatchObject({ ok: false });
+    expect(validateFinnUrl({ url: "https://finn.no" })).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    const r = validateFinnUrl(
+      "  https://www.finn.no/realestate/homes/ad.html  ",
+    );
+    expect(r.ok).toBe(true);
+  });
+});

--- a/src/lib/finn/validateFinnUrl.ts
+++ b/src/lib/finn/validateFinnUrl.ts
@@ -1,0 +1,37 @@
+import { FINN_ERROR_MESSAGES, type FinnUrlValidation } from "./types";
+
+/**
+ * Hostname allowlist enforced before any outbound fetch.
+ *
+ * Matches `design.md` D4: only `www.finn.no` and bare `finn.no` are
+ * accepted. Everything else (other Norwegian classifieds, internal IPs,
+ * unrelated domains) is rejected without a network request — closing
+ * the SSRF hole that an unrestricted fetch-by-URL endpoint would open.
+ *
+ * We additionally reject non-`https` schemes. FINN serves https; any
+ * `http://` URL is suspicious enough that we'd rather fail loud.
+ */
+const ALLOWED_HOSTS = new Set<string>(["finn.no", "www.finn.no"]);
+
+export function validateFinnUrl(input: unknown): FinnUrlValidation {
+  if (typeof input !== "string" || input.trim().length === 0) {
+    return { ok: false, error: FINN_ERROR_MESSAGES.malformedUrl };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(input.trim());
+  } catch {
+    return { ok: false, error: FINN_ERROR_MESSAGES.malformedUrl };
+  }
+
+  if (parsed.protocol !== "https:") {
+    return { ok: false, error: FINN_ERROR_MESSAGES.notFinnUrl };
+  }
+
+  if (!ALLOWED_HOSTS.has(parsed.hostname)) {
+    return { ok: false, error: FINN_ERROR_MESSAGES.notFinnUrl };
+  }
+
+  return { ok: true, url: parsed };
+}

--- a/src/lib/properties/types.ts
+++ b/src/lib/properties/types.ts
@@ -40,6 +40,8 @@ export interface Property {
   added_by: string;
   created_at: string;
   updated_at: string;
+  /** Primary image URL — populated by the FINN parser when available. */
+  image_url: string | null;
 }
 
 /** Joined row returned by `get_property_list()`. */
@@ -91,6 +93,8 @@ export interface CreatePropertyInput {
   property_type?: string | null;
   floor?: string | null;
   status_id?: string | null;
+  /** Primary image URL — populated by the FINN parser. Optional. */
+  image_url?: string | null;
 }
 
 export type PropertyPatch = Partial<

--- a/src/server/properties/createProperty.ts
+++ b/src/server/properties/createProperty.ts
@@ -71,6 +71,7 @@ export async function createProperty(
       floor: input.floor ?? null,
       status_id: statusId,
       added_by: user.id,
+      image_url: input.image_url ?? null,
     })
     .select("id")
     .single<Pick<Property, "id">>();

--- a/supabase/migrations/20260503000001_properties_image_url.sql
+++ b/supabase/migrations/20260503000001_properties_image_url.sql
@@ -1,0 +1,18 @@
+-- properties.image_url — add a nullable text column for the FINN listing's
+-- primary image URL.
+--
+-- Owned by the `properties-finn-import` capability. We only store the URL
+-- (pointing at FINN's CDN). No image is downloaded or cached on our side;
+-- if FINN expires or moves the URL the property card falls back to the
+-- placeholder. A separate `properties-images` capability will own user-
+-- uploaded photos in Supabase Storage.
+--
+-- Idempotent so the migration is safe to re-run on environments that
+-- already pulled the column in via an earlier branch.
+
+alter table public.properties
+    add column if not exists image_url text;
+
+comment on column public.properties.image_url is
+    'Primary image URL for the listing. Populated by the FINN parser when '
+    'available; otherwise NULL. Not downloaded — only referenced.';

--- a/tests/e2e/finn-import.spec.ts
+++ b/tests/e2e/finn-import.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * E2E specs for the `properties-finn-import` capability.
+ *
+ * Spec mapping (openspec/changes/properties-finn-import/specs/properties-finn-import/spec.md):
+ *   - "NyBoligForm tab switcher" — Fra FINN-lenke is the default tab.
+ *   - "Successful prefill" — paste a (mocked) URL → form prefills →
+ *     switches to Manuelt → save lands the parsed values on the row.
+ *   - "Parse failure falls back to manual" — error path keeps the form
+ *     usable.
+ *
+ * The route handler is intercepted via Playwright's `page.route()` so
+ * the test never hits real FINN. A future revision should also exercise
+ * the genuine /api/properties/parse-finn end-to-end against a Supabase
+ * harness; for now, mocking it keeps the test deterministic.
+ *
+ * Marked fixme until the Supabase + dev users harness is ready for this
+ * branch (mirrors tests/e2e/properties.spec.ts).
+ */
+
+test.describe("FINN import — paste URL → prefill → save", () => {
+  test.fixme(
+    true,
+    "Awaits Supabase + dev users via scripts/seed-dev-users.mjs.",
+  );
+
+  test("default tab is FINN; URL paste prefills + saves", async ({ page }) => {
+    // Mock the parse-finn route before navigating.
+    await page.route("**/api/properties/parse-finn", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          data: {
+            address: "Storgata 1, 0182 Oslo",
+            price: 5_250_000,
+            bra: 72.5,
+            primary_rooms: 3,
+            bedrooms: 2,
+            bathrooms: 1,
+            year_built: 1932,
+            property_type: "Leilighet",
+            image_url:
+              "https://images.finncdn.no/dynamic/example/listing-1.jpg",
+            finn_link:
+              "https://www.finn.no/realestate/homes/ad.html?finnkode=1",
+            extracted_fields: [
+              "address",
+              "price",
+              "bra",
+              "primary_rooms",
+              "bedrooms",
+              "bathrooms",
+              "year_built",
+              "property_type",
+              "image_url",
+            ],
+          },
+        }),
+      });
+    });
+
+    await page.goto("/dev/login?as=alice");
+    await page.waitForURL(/\/app/);
+    await page.goto("/app/bolig/ny");
+
+    // Default tab is FINN, input is focused.
+    await expect(
+      page.getByRole("tab", { name: "Fra FINN-lenke" }),
+    ).toHaveAttribute("aria-selected", "true");
+    await expect(page.getByLabel("FINN-lenke")).toBeFocused();
+
+    // Paste + submit.
+    await page
+      .getByLabel("FINN-lenke")
+      .fill("https://www.finn.no/realestate/homes/ad.html?finnkode=1");
+    await page.getByRole("button", { name: "Hent fra FINN" }).click();
+
+    // Switches to Manuelt with prefilled values + notice.
+    await expect(
+      page.getByRole("tab", { name: "Manuelt" }),
+    ).toHaveAttribute("aria-selected", "true");
+    await expect(page.getByLabel("Adresse")).toHaveValue(
+      "Storgata 1, 0182 Oslo",
+    );
+    await expect(page.getByLabel("Totalpris (kr)")).toHaveValue("5250000");
+    await expect(
+      page.getByText(/Hentet \d+ felter fra FINN/),
+    ).toBeVisible();
+
+    // Save and verify the property landed.
+    await page.getByRole("button", { name: "Legg til bolig" }).click();
+    await page.waitForURL(/\/app\/bolig\/.+\/oversikt/);
+  });
+
+  test("non-FINN URL surfaces the Norwegian error inline", async ({ page }) => {
+    await page.route("**/api/properties/parse-finn", async (route) => {
+      await route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error: "URL må være en FINN-annonse",
+        }),
+      });
+    });
+
+    await page.goto("/dev/login?as=alice");
+    await page.goto("/app/bolig/ny");
+    await page
+      .getByLabel("FINN-lenke")
+      .fill("https://example.com/not-finn");
+    await page.getByRole("button", { name: "Hent fra FINN" }).click();
+    await expect(
+      page.getByText("URL må være en FINN-annonse"),
+    ).toBeVisible();
+    // Stays on FINN tab.
+    await expect(
+      page.getByRole("tab", { name: "Fra FINN-lenke" }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/tests/fixtures/finn/listing-1.html
+++ b/tests/fixtures/finn/listing-1.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<!--
+  SYNTHETIC FIXTURE — modeled after a typical FINN ad page.
+
+  When real anonymized FINN HTML becomes available, replace this file
+  (and `listing-2.html`) with the captured markup. Anonymize phone
+  numbers, agent names, and finnkode IDs first.
+
+  Field coverage in this fixture:
+    - JSON-LD: address (via name), price, image, floorSize (BRA),
+      yearBuilt, category (property type), numberOfBedrooms.
+    - CSS fallback: not exercised here; see listing-2.html.
+-->
+<html lang="nb">
+  <head>
+    <meta charset="utf-8" />
+    <title>Storgata 1, 0182 Oslo — FINN-eiendom</title>
+    <meta property="og:image" content="https://images.finncdn.no/dynamic/example/listing-1.jpg" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "Storgata 1, 0182 Oslo",
+        "description": "Lys 3-roms leilighet i sentrum.",
+        "image": "https://images.finncdn.no/dynamic/example/listing-1.jpg",
+        "category": "Leilighet",
+        "yearBuilt": 1932,
+        "numberOfBedrooms": 2,
+        "numberOfRooms": 3,
+        "floorSize": {
+          "@type": "QuantitativeValue",
+          "value": 72.5,
+          "unitCode": "MTK"
+        },
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "Storgata 1",
+          "postalCode": "0182",
+          "addressLocality": "Oslo"
+        },
+        "offers": {
+          "@type": "Offer",
+          "price": 5250000,
+          "priceCurrency": "NOK",
+          "availability": "https://schema.org/InStock"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": []
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Storgata 1, 0182 Oslo</h1>
+    <section>
+      <dl>
+        <dt>Prisantydning</dt>
+        <dd>5 250 000 kr</dd>
+        <dt>Felleskostnader</dt>
+        <dd>3 200 kr/mnd</dd>
+        <dt>Boligtype</dt>
+        <dd>Leilighet</dd>
+        <dt>Bruksareal</dt>
+        <dd>72,5 m²</dd>
+        <dt>Soverom</dt>
+        <dd>2</dd>
+        <dt>Byggeår</dt>
+        <dd>1932</dd>
+      </dl>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/finn/listing-2.html
+++ b/tests/fixtures/finn/listing-2.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<!--
+  SYNTHETIC FIXTURE — exercises the CSS-selector fallback path.
+
+  Deliberately omits JSON-LD so the parser must fall back to the
+  labelled-value extraction in src/lib/finn/parse.ts.
+  Replace with real anonymized FINN HTML when available.
+-->
+<html lang="nb">
+  <head>
+    <meta charset="utf-8" />
+    <title>Bjørkeveien 12, 7010 Trondheim</title>
+    <meta property="og:image" content="https://images.finncdn.no/dynamic/example/listing-2.jpg" />
+  </head>
+  <body>
+    <h1>Bjørkeveien 12, 7010 Trondheim</h1>
+    <main>
+      <table>
+        <tbody>
+          <tr><th>Prisantydning</th><td>3 950 000,-</td></tr>
+          <tr><th>Boligtype</th><td>Enebolig</td></tr>
+          <tr><th>Bruksareal</th><td>120 m²</td></tr>
+          <tr><th>Primærrom</th><td>110 m²</td></tr>
+          <tr><th>Soverom</th><td>4</td></tr>
+          <tr><th>Bad</th><td>2</td></tr>
+          <tr><th>Byggeår</th><td>1985</td></tr>
+        </tbody>
+      </table>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/finn/listing-3-partial.html
+++ b/tests/fixtures/finn/listing-3-partial.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<!--
+  SYNTHETIC FIXTURE — partial extraction case.
+
+  Only address (h1) + image are findable. No JSON-LD, no labelled
+  fields. Confirms the parser doesn't throw when most fields are
+  missing.
+-->
+<html lang="nb">
+  <head>
+    <meta charset="utf-8" />
+    <meta property="og:image" content="https://images.finncdn.no/dynamic/example/listing-3.jpg" />
+  </head>
+  <body>
+    <h1>Sjøgata 4, 8006 Bodø</h1>
+    <p>Annonsen er fjernet eller mangler informasjon.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Implements `properties-finn-import` per `openspec/changes/properties-finn-import/`. Resolves the first round of post-launch user feedback ("fakta som kan hentes av FINN annonsen burde bli lagt inn selv").

- **Server-side parser** (`src/lib/finn/`): JSON-LD-first extraction with CSS-selector fallback. Returns a partial — never throws on missing fields.
- **Route handler** `/api/properties/parse-finn`: auth-gated, hostname-allowlisted (finn.no only), 5s timeout, 200KB body cap, structured `{ ok, data | error }` response.
- **NyBoligForm tab switcher**: `Fra FINN-lenke` (default) | `Manuelt`. URL paste → "Hent fra FINN" → form prefills + tab switches to Manual for review/edit.
- **Migration** `20260503000001_properties_image_url.sql`: adds nullable `image_url` text column (idempotent, `if not exists`). Stores the FINN CDN URL — no image download/upload (that's a separate `properties-images` capability later).

## Spec coverage

All 6 requirements implemented (see `openspec/changes/properties-finn-import/specs/properties-finn-import/spec.md`).

## Tests

- 21 new unit tests passing: `validateFinnUrl` (validator decisions), `parseFinnHtml` (against synthetic fixtures), `fetchFinnHtml` (timeout, 404, 5xx, oversized), `parse-finn` route handler (happy / 401 / 400 / fetch-fail).
- Total suite: 188 pass, 125 skipped (no new failures, no regressions).
- E2E `tests/e2e/finn-import.spec.ts` is `test.fixme()`-marked pending the existing dev-users harness.

## Verified locally

- `npm install` ✓ (adds cheerio)
- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm test` ✓ (188 pass / 125 skipped)
- `npm run build` ✓
- `supabase db push` ✓ — image_url column added to dev project

## Decisions beyond spec

- HTTP scheme rejected; only `https://` accepted.
- Subdomains rejected; only `finn.no` and `www.finn.no` exactly.
- Fetch errors return HTTP 200 with `ok: false` for structured-result consistency. Auth/validation errors keep their proper 4xx codes.
- `image_url` is hidden in the form — populated by the parser, not user-editable. Future image-upload capability owns user surface.
- "Hentet N felter" banner additionally lists which Norwegian-labelled fields were prefilled.

## Operational notes

- **Synthetic fixtures**: agent didn't capture real FINN HTML (couldn't from sandbox). Fixtures at `tests/fixtures/finn/` model FINN's typical markup. First post-deploy parse against a real listing should be smoke-tested manually; capture real anonymized HTML if synthetic shape diverges.
- **No rate limiting**: auth gate keeps random-internet abuse out. Add per-user counter if a real user hammers the endpoint.
- **No FINN-block monitoring**: TODO in route handler points at the right hook for when extraction fields < 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)