### PR TITLE
v2: properties-finn-fields — budget + energi fields, dedupe, Kostnader card (DRAFT — spec only)

### DIFF
--- a/openspec/changes/properties-finn-fields/.openspec.yaml
+++ b/openspec/changes/properties-finn-fields/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/properties-finn-fields/README.md
+++ b/openspec/changes/properties-finn-fields/README.md
@@ -1,0 +1,3 @@
+# properties-finn-fields
+
+Extend properties + FINN parser with budget-relevant fields: felleskostnader, omkostninger, fellesgjeld, tomteareal, etasje, energimerke, finnkode.

--- a/openspec/changes/properties-finn-fields/design.md
+++ b/openspec/changes/properties-finn-fields/design.md
@@ -1,0 +1,129 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Context
+
+`properties-finn-import` shipped with a deliberately narrow field set. Round-A user feedback says the budget facts (felleskostnader, omkostninger, fellesgjeld) and the energy rating (energimerke) are the next-most-important. They live in FINN's "Nøkkelinfo" / "Økonomi" / "Energi" panels — predictable label strings, less reliable as JSON-LD. Manual users need the same fields available without going through FINN.
+
+Constraints:
+- **Schema additivity**: existing rows must remain valid. All new columns nullable.
+- **No silent re-parse**: existing import flow runs the parser once on URL submit; this change keeps that.
+- **Robustness**: FINN can rename labels. Use multi-string label matching (`"Felleskostnader"`, `"Felleskost/mnd."`, `"Felleskost"`).
+- **Per-household dedupe**: same listing can legitimately exist across households (a friend's couple is also scoring it) — uniqueness is scoped to the household.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add 8 fields to `properties` and to the parser, all nullable.
+- Surface Kostnader on Oversikt; surface `felleskostnader` on PropertyCard.
+- Reject same-finnkode re-imports per household (SQL + UX).
+- Manual entry can fill all new fields without going through FINN.
+
+**Non-Goals:**
+- Re-parsing existing properties to backfill new fields.
+- Backfilling `finnkode` from existing `finn_link` URLs.
+- Adding any new external dependency — `cheerio` already covers the parsing.
+- Currency conversion or price-history tracking.
+- Validation of energimerke against year_built (could be useful later — out of scope).
+
+## Decisions
+
+### D1. Real columns, not a JSON sidecar
+
+**Choice**: 8 new columns on `properties`, each typed appropriately. No `extra_fields jsonb`.
+
+**Alternative considered**: a single `properties.extra jsonb` column.
+
+**Rationale**: SQL filter/sort/aggregate stays trivial ("show me properties under 4M with felleskostnader < 5000"). Type safety in the TypeScript layer. RLS reuses the same row policy. The cost of 8 nullable columns on a small table is negligible. JSON would force every consumer to learn the inner shape.
+
+### D2. `etasje` is text, not int
+
+**Choice**: `etasje text` (nullable).
+
+**Alternative considered**: `etasje_int int` + `etasje_total_int int` ("4 av 5") + a normalized accessor.
+
+**Rationale**: FINN ships strings: `"4. etasje"`, `"1. etasje av 3"`, `"U. etasje"` (basement), `"Loft"`. Coercing to int loses meaning. A 20-char text column carries verbatim what FINN said and what the user wants to display. Sort/filter use cases (e.g. "ground-floor only") aren't on the roadmap.
+
+### D3. Energimerke as two columns: letter + color
+
+**Choice**: `energimerke_letter char(1)` + `energimerke_color text`. Both nullable. CHECK constraints:
+- `energimerke_letter IN ('A','B','C','D','E','F','G')` when not null.
+- `energimerke_color IN ('dark_green','light_green','yellow','orange','red')` when not null.
+
+**Alternative considered**: one `energimerke jsonb`, or one `energimerke_code` enum like `A_dark_green`.
+
+**Rationale**: separate cols are filterable and sortable independently. CHECK constraints catch parser bugs at write time. JSON would hide the shape; concatenated codes lose semantic clarity.
+
+### D4. `finnkode` partial unique index per household
+
+**Choice**: `CREATE UNIQUE INDEX properties_household_finnkode_uniq ON properties (household_id, finnkode) WHERE finnkode IS NOT NULL`.
+
+**Alternative considered**: app-only check; or a unique constraint without the partial WHERE clause.
+
+**Rationale**:
+- Partial-WHERE allows multiple manually-entered (no finnkode) rows in the same household.
+- Per-household scope lets two unrelated households score the same listing.
+- SQL-level enforcement is belt-and-braces against race conditions in the app-level pre-check.
+
+### D5. App-level dedupe pre-check before parse
+
+**Choice**: in `POST /api/properties/parse-finn`, before fetching FINN, extract the finnkode from the URL and check `properties` for `(household_id = current, (finnkode = X OR finn_link = url))`. If found, return `{ ok: false, error: "Du har allerede denne boligen", existing_id }` with a 409 status.
+
+**Alternative considered**: only enforce at insert time via D4's unique index.
+
+**Rationale**: pre-check skips the FINN fetch entirely (saves a network round-trip + saves quota). Surfaces a friendlier error with a deep link to the existing property — far better UX than letting the user fill out the whole form just to be rejected at submit.
+
+### D6. Parser: CSS-label fallback for nearly all new fields
+
+**Choice**: parser tries JSON-LD first (in case FINN ever exposes these structurally), then falls back to label-based CSS extraction:
+- `Felleskost/mnd.`, `Felleskostnader` → `felleskostnader`
+- `Omkostninger` → `omkostninger`
+- `Fellesgjeld`, `Andel fellesgjeld` → `fellesgjeld`
+- `Tomteareal` → `tomteareal`
+- `Etasje` → `etasje` (verbatim text)
+- Energimerke widget → `energimerke_letter` + `energimerke_color` via DOM heuristics (badge with class containing energy-letter, plus the surrounding container's CSS class hinting at color tier).
+
+**Rationale**: FINN's JSON-LD doesn't cover most of these. The label-based fallbacks already work for BRA / Byggeår; pattern is proven.
+
+### D7. Energimerke parsing isolated in its own module
+
+**Choice**: `src/lib/finn/extractEnergimerke.ts` with its own unit tests. Parses out `{ letter: 'A'..'G' | null, color: <enum> | null }` from a Cheerio root.
+
+**Rationale**: it's the most fragile extractor (depends on FINN's badge widget structure). Isolating it makes targeted fixture-replacement easy when FINN changes the widget without touching the rest of the parser.
+
+### D8. PropertyCard adds **only** `felleskostnader`, the rest go on Oversikt
+
+**Choice**: PropertyCard renders `+ kr {felleskostnader} / mnd` under the price line, only when not null. Other new fields (omkostninger, fellesgjeld, tomteareal, etasje, energimerke) appear on the Oversikt tab in a Kostnader card.
+
+**Rationale**: user direction — keep the card scannable, push detail to the click-through. Felleskostnader is uniquely card-worthy because it changes the felt monthly cost; everything else is one-time / contextual / status-y.
+
+### D9. Kostnader card on Oversikt hides when fully empty
+
+**Choice**: if every new column on the row is null, do not render the Kostnader card at all. Otherwise render with the populated lines only — never a row of `—`.
+
+**Rationale**: existing properties + skip-the-form users shouldn't see an empty section. The card is a value-add when filled, noise when empty.
+
+### D10. No `properties.image_url` re-touching
+
+**Choice**: ignore image fields. `properties-images` already owns the photo story.
+
+**Rationale**: keeping this change scope-clean.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Energimerke widget changes shape, parser silently returns null | D7's isolation + unit tests with multiple fixtures (A-dark_green, E-orange, missing). Manual fill always works. |
+| Felleskostnader label varies ("Felleskost/mnd.", "Felleskost", "Felleskostnader") | Match all known variants in a single pass; log when no variant matches so we can add new aliases. |
+| User has 50 existing properties from before this change → all new fields are null → Kostnader card hidden everywhere | Acceptable. They can fill manually on edit, or re-import. We don't auto-backfill. |
+| Migration unique index fails because two duplicate (household_id, finnkode) rows already exist | Won't happen: `finnkode` column is brand new; every existing row has it null; partial WHERE excludes them. |
+| Adding a partial unique index triggers a long lock on a hot table | `properties` is small (per-household, hundreds tops). Run as a normal migration; no concurrency story needed. |
+| Dedupe check is racy across concurrent requests (two tabs open) | D4's SQL unique index is the backstop. App pre-check is for UX, not correctness. |
+| `etasje` free text invites garbage ("ÅÅÅÅ") | Validate to ≤20 chars and visually trimmed. Free-text is the only realistic option. |
+
+## Resolved decisions
+
+### D11. Field display order on Oversikt Kostnader card
+
+**Choice**: top-to-bottom: felleskostnader, omkostninger, fellesgjeld, energimerke, tomteareal, etasje. Money first (most decision-relevant), then energi, then physical specs.
+
+**Rationale**: matches the order users will scan when shopping on monthly cost.

--- a/openspec/changes/properties-finn-fields/proposal.md
+++ b/openspec/changes/properties-finn-fields/proposal.md
@@ -1,0 +1,46 @@
+> Conventions: see `openspec/conventions.md`.
+
+## Why
+
+The MVP `properties-finn-import` parser extracts the 9 most basic fields (address, price, BRA, primærrom, bedrooms, bathrooms, year_built, property_type, image_url). It deliberately deferred everything else as "best-effort" / "fill in manually". User feedback after round A is that the **budget-relevant** facts on every FINN ad — felleskostnader, omkostninger, fellesgjeld — are exactly what couples compare on, and asking users to retype them defeats the auto-fill promise. Energy rating (energimerke) is the next most-asked-about fact because it foreshadows monthly heating cost.
+
+Manual entry users hit the same gap: there's no place to put these numbers today, so they end up scribbled in scoring notes or left out entirely.
+
+## What Changes
+
+- **Schema**: add 8 nullable columns to `properties` — `felleskostnader` (int, NOK/mnd), `omkostninger` (int, NOK), `fellesgjeld` (int, NOK), `tomteareal` (int, m²), `etasje` (text — FINN ships strings like "4. etasje" or "U."), `energimerke_letter` (char(1), `A`..`G`), `energimerke_color` (text, one of `dark_green`/`light_green`/`yellow`/`orange`/`red`), `finnkode` (int).
+- **Partial unique index** on `(household_id, finnkode) WHERE finnkode IS NOT NULL` so re-importing the same listing in the same household is rejected at the SQL level.
+- **Server-side dedupe check** in the FINN import flow: before parsing, look up `finn_link` or `finnkode` against the user's household — if a match exists, surface "Du har allerede denne boligen" with a link to it (no parse, no insert).
+- **Parser**: extend `ParsedListing` and `parseFinnHtml` to populate the eight new fields. JSON-LD-first where the data exists (rare for these fields); otherwise CSS-label fallback against FINN's standard "key facts" rows. Missing fields stay null per the existing partial-success contract (D8 of `properties-finn-import`).
+- **NyBoligForm**: add the new fields to the manual section so non-FINN entries can fill them too. Group them as a "Kostnader" block + an "Energi"-row (compact dropdown for letter + color).
+- **Oversikt**: add a "Kostnader" card showing felleskostnader, omkostninger, fellesgjeld, energimerke, tomteareal, etasje when set. Anything null hidden, not shown as `—`.
+- **PropertyCard**: add `felleskostnader` underneath the price line (compact: `+ kr 4 250 / mnd`). Rest only on the detail view per user direction "keep cards simple".
+
+## Out of MVP scope (future)
+
+- **Re-parse on URL change** — still deferred (carried from `properties-finn-import`).
+- **Multiple gallery images** — still deferred (`properties-images-gallery` later).
+- **Full description text + agent / megler info** — low signal-to-noise for scoring decisions; users have notes for free-form context.
+- **Visningstider / open-house dates** — too volatile, would go stale.
+- **Backfilling `finnkode` for existing rows** — added column stays null; no migration of historical rows. If a user wants to dedupe an old listing, re-import it.
+- **Unit conversion / price normalization** — store FINN's value verbatim. Currency is always NOK.
+- **i18n of new field labels** — Norwegian only, hardcoded JSX literals per `conventions.md`.
+
+## Capabilities
+
+### New Capabilities
+- `properties-finn-fields`: schema migration for the 8 columns + partial unique index, parser extensions, dedupe check in import flow, Kostnader block in NyBoligForm, Kostnader card on Oversikt, felleskostnader line on PropertyCard.
+
+### Modified Capabilities
+- `properties`: `properties` table gains 8 columns + a partial unique index; manual entry form gains a Kostnader block and an Energi row; Oversikt gains a Kostnader card; PropertyCard adds a felleskostnader line under the price.
+- `properties-finn-import`: `ParsedListing` extends with 8 new keys; `parseFinnHtml` populates them best-effort; the parse-FINN flow gains a pre-parse dedupe check against `finn_link` / `finnkode`.
+
+## Impact
+
+- **Database**: one migration adds 8 nullable columns + 1 partial unique index. No data backfill. No existing-row impact.
+- **Backend**: `src/lib/finn/types.ts` `ParsedListing` widens (additive, won't break callers). `src/lib/finn/parse.ts` gains 8 new field extractors. New module `src/lib/finn/extractEnergimerke.ts` (separate because of the letter+color pairing). Server action `createProperty` and the parse-FINN route both get a dedupe check.
+- **UI**: NyBoligForm gains a "Kostnader" section + an "Energi" row; Oversikt gains a Kostnader card; PropertyCard gains one line. No new pages.
+- **Tests**: parser unit tests (against existing fixtures + a new one with energimerke + costs filled in); migration smoke test; e2e test for the dedupe path.
+- **Storage / cost**: zero — schema only.
+- **Privacy**: no new PII. All fields are public listing facts.
+- **Compatibility**: existing properties with all-null new fields render the same as today (Kostnader card hidden when empty, PropertyCard felleskostnader line hidden when null).

--- a/openspec/changes/properties-finn-fields/specs/properties-finn-fields/spec.md
+++ b/openspec/changes/properties-finn-fields/specs/properties-finn-fields/spec.md
@@ -1,0 +1,143 @@
+## ADDED Requirements
+
+### Requirement: Schema gains budget and metadata fields
+
+The `properties` table SHALL gain eight nullable columns: `felleskostnader` (int, NOK/month), `omkostninger` (int, NOK), `fellesgjeld` (int, NOK), `tomteareal` (int, m²), `etasje` (text, ≤ 20 chars), `energimerke_letter` (char(1), values `A`..`G` only when not null), `energimerke_color` (text, one of `dark_green`/`light_green`/`yellow`/`orange`/`red` when not null), and `finnkode` (int). Existing rows SHALL remain valid with all eight columns null.
+
+#### Scenario: New columns nullable
+
+- **WHEN** the migration applies against a database that already has property rows
+- **THEN** every existing row continues to satisfy the table constraints
+- **AND** all eight new columns are null on every existing row
+
+#### Scenario: CHECK on energimerke_letter
+
+- **WHEN** an insert or update sets `energimerke_letter` to any value other than null or one of `A`..`G`
+- **THEN** the database SHALL reject the write
+
+#### Scenario: CHECK on energimerke_color
+
+- **WHEN** an insert or update sets `energimerke_color` to any value other than null or one of `dark_green`/`light_green`/`yellow`/`orange`/`red`
+- **THEN** the database SHALL reject the write
+
+### Requirement: Per-household uniqueness on finnkode
+
+The `properties` table SHALL enforce a partial unique index on `(household_id, finnkode)` where `finnkode IS NOT NULL`. The same listing SHALL NOT be added twice to the same household.
+
+#### Scenario: Duplicate finnkode in same household rejected
+
+- **WHEN** a household already has a property with `finnkode = 123456789`
+- **AND** a member tries to insert another property with the same `finnkode` and same `household_id`
+- **THEN** the database SHALL reject the insert with a unique-violation error
+
+#### Scenario: Same finnkode allowed across households
+
+- **WHEN** household A has a property with `finnkode = 123456789`
+- **AND** household B inserts a property with `finnkode = 123456789`
+- **THEN** the insert succeeds — uniqueness is per-household
+
+#### Scenario: Multiple null finnkode allowed in same household
+
+- **WHEN** a household has 5 manually-entered properties with `finnkode = NULL`
+- **THEN** all 5 rows coexist — the partial-WHERE excludes nulls from the unique constraint
+
+### Requirement: Pre-parse dedupe check in import flow
+
+`POST /api/properties/parse-finn` SHALL look up the user's household for an existing property whose `finn_link` matches the input URL or whose `finnkode` matches the URL's extracted finnkode, before fetching FINN. If a match is found, the response SHALL be `{ ok: false, error: "Du har allerede denne boligen", existing_id: <uuid> }` with status 409, and no outbound fetch SHALL occur.
+
+#### Scenario: Existing property by finnkode
+
+- **WHEN** the user POSTs a FINN URL whose finnkode matches an existing property in their household
+- **THEN** the response is 409 with `{ ok: false, error: "Du har allerede denne boligen", existing_id }`
+- **AND** no outbound fetch to FINN was made
+
+#### Scenario: Existing property by exact finn_link
+
+- **WHEN** the user POSTs a FINN URL whose `finn_link` is byte-exact-equal to an existing property's `finn_link` in their household
+- **THEN** the response is 409 with `{ ok: false, error: "Du har allerede denne boligen", existing_id }`
+
+#### Scenario: No existing match — proceeds to fetch
+
+- **WHEN** the URL has no matching `finnkode` and no matching `finn_link` in the household
+- **THEN** the route handler proceeds to fetch and parse as before
+
+### Requirement: Parser populates new fields
+
+`parseFinnHtml` SHALL attempt to extract `felleskostnader`, `omkostninger`, `fellesgjeld`, `tomteareal`, `etasje`, `energimerke_letter`, `energimerke_color`, and `finnkode`, and SHALL include each successfully populated key in `extracted_fields`. Failure to extract any one field SHALL NOT prevent extraction of the others.
+
+#### Scenario: Full extraction
+
+- **WHEN** the parser is given a FINN HTML fixture that contains all key labels and an energimerke badge
+- **THEN** the returned `ParsedListing` populates all eight new fields
+- **AND** `extracted_fields` includes all eight new keys
+
+#### Scenario: Partial extraction — only costs
+
+- **WHEN** the parser sees `Felleskost/mnd.`, `Omkostninger`, and `Fellesgjeld` rows but no energimerke widget
+- **THEN** the three cost fields are populated
+- **AND** `energimerke_letter` and `energimerke_color` are null
+- **AND** `extracted_fields` includes the three populated keys but not the energi keys
+
+#### Scenario: finnkode extracted from URL when label missing
+
+- **WHEN** the parser sees a FINN URL containing `?finnkode=123456789` and no `finnkode` row in the page
+- **THEN** `finnkode` is populated from the URL parameter
+
+#### Scenario: etasje preserved as verbatim text
+
+- **WHEN** the FINN page renders `Etasje: U. etasje`
+- **THEN** `etasje` equals exactly `"U. etasje"` (no parsing into int)
+
+### Requirement: Manual entry supports new fields
+
+`NyBoligForm` SHALL render input controls for all eight new fields. Owner and member SHALL be able to fill, edit, and submit these fields. Viewers SHALL see the controls disabled or absent. All eight fields SHALL be optional — submitting with all eight empty SHALL succeed (subject to the existing required-fields contract for `address`, etc.).
+
+#### Scenario: Owner fills cost fields
+
+- **WHEN** an `owner` enters values for `felleskostnader`, `omkostninger`, and `fellesgjeld` and submits
+- **THEN** the new property row contains those three values, and the other five new fields are null
+
+#### Scenario: All new fields optional
+
+- **WHEN** an `owner` submits the form filling only the previously-required fields and leaving all eight new fields empty
+- **THEN** the insert succeeds and the row has null in all eight new columns
+
+#### Scenario: energimerke as paired dropdowns
+
+- **WHEN** the user picks a letter `A`..`G` for energimerke
+- **THEN** the form renders a paired color dropdown with values `dark_green`/`light_green`/`yellow`/`orange`/`red`
+- **AND** picking a letter without a color (or vice versa) is allowed — both are independently nullable
+
+### Requirement: Oversikt renders Kostnader card when any field is set
+
+The Oversikt tab SHALL render a Kostnader card containing felleskostnader, omkostninger, fellesgjeld, energimerke (letter + color), tomteareal, and etasje, in that order. Lines whose underlying field is null SHALL NOT render. The card itself SHALL NOT render when all six underlying fields are null.
+
+#### Scenario: All fields filled
+
+- **WHEN** a property has values for all six display fields
+- **THEN** the Kostnader card renders all six lines in the spec order
+
+#### Scenario: Only felleskostnader filled
+
+- **WHEN** a property has only `felleskostnader` set
+- **THEN** the Kostnader card renders one line for felleskostnader and no other lines
+
+#### Scenario: All fields null — card hidden
+
+- **WHEN** a property has null in all six display fields
+- **THEN** the Kostnader card does not render at all (not even a heading)
+
+### Requirement: PropertyCard shows felleskostnader when set
+
+`PropertyCard` SHALL render a felleskostnader line under the price line when `felleskostnader` is not null. The line SHALL show `+ kr {value} / mnd` formatted with Norwegian thousand separators. When `felleskostnader` is null, no line SHALL render and the card height SHALL be unchanged from the previous behavior.
+
+#### Scenario: Card with felleskostnader
+
+- **WHEN** a property has `felleskostnader = 4250`
+- **THEN** the card renders `+ kr 4 250 / mnd` immediately under the price
+
+#### Scenario: Card without felleskostnader
+
+- **WHEN** a property has `felleskostnader = null`
+- **THEN** no felleskostnader line is rendered
+- **AND** the card matches the pre-change visual layout

--- a/openspec/changes/properties-finn-fields/tasks.md
+++ b/openspec/changes/properties-finn-fields/tasks.md
@@ -1,0 +1,70 @@
+> Conventions: see `openspec/conventions.md`.
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `supabase/migrations/<timestamp>_properties_finn_fields.sql` adding 8 nullable columns: `felleskostnader int`, `omkostninger int`, `fellesgjeld int`, `tomteareal int`, `etasje text`, `energimerke_letter char(1)`, `energimerke_color text`, `finnkode int`.
+- [ ] 1.2 Add CHECK constraints: `energimerke_letter IN ('A','B','C','D','E','F','G')` (allowing null) and `energimerke_color IN ('dark_green','light_green','yellow','orange','red')` (allowing null).
+- [ ] 1.3 Add `etasje` length constraint: `CHECK (etasje IS NULL OR length(etasje) <= 20)`.
+- [ ] 1.4 Add partial unique index: `CREATE UNIQUE INDEX properties_household_finnkode_uniq ON properties (household_id, finnkode) WHERE finnkode IS NOT NULL`.
+- [ ] 1.5 Re-run `supabase db reset` locally; verify migration applies cleanly + seed.sql still loads.
+
+## 2. Types + parser
+
+- [ ] 2.1 Extend `src/lib/finn/types.ts` `ParsedListing` with the 8 new fields (all `| null`). Extend `ParsedListingKey` union.
+- [ ] 2.2 Add label-based extractors in `src/lib/finn/parse.ts`: `extractFelleskostnader`, `extractOmkostninger`, `extractFellesgjeld`, `extractTomteareal`, `extractEtasje`. Reuse `findLabelledValue` + Norwegian-int parsing where applicable.
+- [ ] 2.3 New module `src/lib/finn/extractEnergimerke.ts` exporting `(($: cheerio.CheerioAPI) => { letter: 'A'|...|'G'|null, color: <enum>|null })`. Strategy: look for FINN's energy badge by class/data-attr; fall back to scanning text content for "Energimerking: A" patterns.
+- [ ] 2.4 Add `extractFinnkode` — parse the URL query string first; fall back to scanning page for `finnkode=<digits>`.
+- [ ] 2.5 Wire all new extractors into `parseFinnHtml`'s merge pipeline. Add each populated key to `extracted_fields`.
+
+## 3. Dedupe pre-check
+
+- [ ] 3.1 Add `src/server/properties/findExistingByFinnRef.ts` exporting `findExistingByFinnRef(householdId: string, url: string): Promise<{ id: string } | null>`. Logic: derive `finnkode` from URL; query `properties` where `household_id = X AND (finnkode = Y OR finn_link = url)`; return first match.
+- [ ] 3.2 In `src/app/api/properties/parse-finn/route.ts`, after auth + URL validation but before `fetchFinnHtml`, call `findExistingByFinnRef`. On match, return `{ ok: false, error: "Du har allerede denne boligen", existing_id }` with status 409.
+- [ ] 3.3 Add a Norwegian message constant to `FINN_ERROR_MESSAGES`: `alreadyOwned: "Du har allerede denne boligen"`.
+
+## 4. NyBoligForm — Kostnader + Energi inputs
+
+- [ ] 4.1 Add a "Kostnader" section under the existing manual fields with three int inputs: Felleskost/mnd, Omkostninger, Fellesgjeld. Use the existing `<NumberInput>` (or equivalent) — Norwegian thousand-separator formatting, accept blank.
+- [ ] 4.2 Add a "Tomteareal" int input + an "Etasje" text input (max 20 chars). Place under "Boligdetaljer" group.
+- [ ] 4.3 Add an "Energimerke" pair: `<select>` for letter (A..G + blank) and `<select>` for color (5 colors + blank). Display them inline. Both independently nullable.
+- [ ] 4.4 Wire form submit through to `createProperty` server action — extend its input schema and insert payload to include the 8 new fields.
+- [ ] 4.5 On a successful FINN parse (after the route returns), populate the new fields in form state alongside the existing ones. Update the prefill notice to count populated new fields too.
+
+## 5. Oversikt — Kostnader card
+
+- [ ] 5.1 New component `src/components/properties/KostnaderCard.tsx` taking the 6 display fields. Render lines for non-null values only. Letter + color render as a small colored pill (e.g. green pill with "A" inside).
+- [ ] 5.2 Mount `<KostnaderCard>` on the Oversikt tab below the address heading. Hide entirely when all 6 fields null.
+- [ ] 5.3 Add a tiny utility `src/lib/properties/formatNok.ts` for `kr 4 250 / mnd` formatting (Norwegian non-breaking space thousand sep).
+
+## 6. PropertyCard — felleskostnader line
+
+- [ ] 6.1 In `PropertyCard.tsx`, under the price line, conditionally render `+ kr {felleskostnader} / mnd` when `felleskostnader != null`.
+- [ ] 6.2 Visual review: card height should not jump when felleskostnader missing — verify with a fixture-style test rendering both cases.
+
+## 7. Server action + edit flow
+
+- [ ] 7.1 Extend `createProperty` server action to accept the 8 new optional fields and insert them.
+- [ ] 7.2 Extend the property edit flow on Oversikt (the existing form) so all 8 new fields are editable post-creation. Same validation as create.
+- [ ] 7.3 `listProperties` and `getProperty` server methods select the new columns and pass through to the client.
+
+## 8. Tests
+
+- [ ] 8.1 **Unit (Vitest)**: extractors (`extractFelleskostnader`, etc.) against label-row HTML snippets. Cover blank, present, multiple variants of label text.
+- [ ] 8.2 **Unit**: `extractEnergimerke` — fixture for A/dark_green, E/orange, missing widget; partial (letter only).
+- [ ] 8.3 **Unit**: `extractFinnkode` — URL parse, page-text fallback, neither path matches (returns null).
+- [ ] 8.4 **Unit**: `parseFinnHtml` end-to-end against an extended fixture containing all 8 new fields. Assert `extracted_fields` includes the new keys.
+- [ ] 8.5 **Integration / Route**: `POST /api/properties/parse-finn` dedupe path — happy-path 200 when no existing match, 409 when `finnkode` matches, 409 when `finn_link` matches. Asserts no outbound fetch in the 409 cases.
+- [ ] 8.6 **Integration**: insert via server action with all 8 fields set; round-trip select returns the same values.
+- [ ] 8.7 **Integration**: insert two rows in same household with same `finnkode` — second SHALL fail with the unique-violation error.
+- [ ] 8.8 **E2E (Playwright)**: paste a FINN URL → form prefills new Kostnader + Energi fields → save → Oversikt shows the Kostnader card + PropertyCard shows felleskostnader line.
+
+## 9. Documentation
+
+- [ ] 9.1 Update `docs/architecture/finn-import.md` with the 8 new fields, the `extractEnergimerke` module, and the dedupe pre-check.
+- [ ] 9.2 Update the `properties-finn-import` proposal `## Out of MVP scope` section: remove "deep field extraction (omkostninger, felleskostnader, primærrom split) is best-effort" since these now extracted explicitly.
+- [ ] 9.3 README: under "Adding a property", note the dedupe behavior ("if you've already added this listing, we'll show you the existing one instead of duplicating").
+
+## 10. Operational
+
+- [ ] 10.1 Add a `// TODO(monitoring)` comment near the new extractors noting where to add a Sentry/log call when an extractor returns null repeatedly. Same pattern as `properties-finn-import` task 8.2 — actual instrumentation deferred.
+- [ ] 10.2 Manual smoke check on at least 3 distinct FINN listings of different property types (leilighet, enebolig, rekkehus). Record which fields each one populated in a comment in the PR description.

--- a/openspec/changes/properties-finn-fields/tasks.md
+++ b/openspec/changes/properties-finn-fields/tasks.md
@@ -2,11 +2,11 @@
 
 ## 1. Schema migration
 
-- [ ] 1.1 Create `supabase/migrations/<timestamp>_properties_finn_fields.sql` adding 8 nullable columns: `felleskostnader int`, `omkostninger int`, `fellesgjeld int`, `tomteareal int`, `etasje text`, `energimerke_letter char(1)`, `energimerke_color text`, `finnkode int`.
-- [ ] 1.2 Add CHECK constraints: `energimerke_letter IN ('A','B','C','D','E','F','G')` (allowing null) and `energimerke_color IN ('dark_green','light_green','yellow','orange','red')` (allowing null).
-- [ ] 1.3 Add `etasje` length constraint: `CHECK (etasje IS NULL OR length(etasje) <= 20)`.
-- [ ] 1.4 Add partial unique index: `CREATE UNIQUE INDEX properties_household_finnkode_uniq ON properties (household_id, finnkode) WHERE finnkode IS NOT NULL`.
-- [ ] 1.5 Re-run `supabase db reset` locally; verify migration applies cleanly + seed.sql still loads.
+- [x] 1.1 Create `supabase/migrations/<timestamp>_properties_finn_fields.sql` adding 8 nullable columns: `felleskostnader int`, `omkostninger int`, `fellesgjeld int`, `tomteareal int`, `etasje text`, `energimerke_letter char(1)`, `energimerke_color text`, `finnkode int`.
+- [x] 1.2 Add CHECK constraints: `energimerke_letter IN ('A','B','C','D','E','F','G')` (allowing null) and `energimerke_color IN ('dark_green','light_green','yellow','orange','red')` (allowing null).
+- [x] 1.3 Add `etasje` length constraint: `CHECK (etasje IS NULL OR length(etasje) <= 20)`.
+- [x] 1.4 Add partial unique index: `CREATE UNIQUE INDEX properties_household_finnkode_uniq ON properties (household_id, finnkode) WHERE finnkode IS NOT NULL`.
+- [x] 1.5 Re-run `supabase db reset` locally; verify migration applies cleanly + seed.sql still loads.
 
 ## 2. Types + parser
 

--- a/openspec/changes/properties-finn-fields/tasks.md
+++ b/openspec/changes/properties-finn-fields/tasks.md
@@ -10,11 +10,11 @@
 
 ## 2. Types + parser
 
-- [ ] 2.1 Extend `src/lib/finn/types.ts` `ParsedListing` with the 8 new fields (all `| null`). Extend `ParsedListingKey` union.
-- [ ] 2.2 Add label-based extractors in `src/lib/finn/parse.ts`: `extractFelleskostnader`, `extractOmkostninger`, `extractFellesgjeld`, `extractTomteareal`, `extractEtasje`. Reuse `findLabelledValue` + Norwegian-int parsing where applicable.
-- [ ] 2.3 New module `src/lib/finn/extractEnergimerke.ts` exporting `(($: cheerio.CheerioAPI) => { letter: 'A'|...|'G'|null, color: <enum>|null })`. Strategy: look for FINN's energy badge by class/data-attr; fall back to scanning text content for "Energimerking: A" patterns.
-- [ ] 2.4 Add `extractFinnkode` — parse the URL query string first; fall back to scanning page for `finnkode=<digits>`.
-- [ ] 2.5 Wire all new extractors into `parseFinnHtml`'s merge pipeline. Add each populated key to `extracted_fields`.
+- [x] 2.1 Extend `src/lib/finn/types.ts` `ParsedListing` with the 8 new fields (all `| null`). Extend `ParsedListingKey` union.
+- [x] 2.2 Add label-based extractors in `src/lib/finn/parse.ts`: `extractFelleskostnader`, `extractOmkostninger`, `extractFellesgjeld`, `extractTomteareal`, `extractEtasje`. Reuse `findLabelledValue` + Norwegian-int parsing where applicable.
+- [x] 2.3 New module `src/lib/finn/extractEnergimerke.ts` exporting `(($: cheerio.CheerioAPI) => { letter: 'A'|...|'G'|null, color: <enum>|null })`. Text-scan strategy: `Energimerking: <letter> - <Norwegian-color>` (real FINN uses Norwegian color words like "Oransje", "Lysegrønn" — module includes a translation table to the schema enum).
+- [x] 2.4 Add `extractFinnkode` — parse the URL query string first; fall back to "FINN-kode" label, then to scanning page for `finnkode=<digits>`.
+- [x] 2.5 Wire all new extractors into `parseFinnHtml`'s merge pipeline. Add each populated key to `extracted_fields`.
 
 ## 3. Dedupe pre-check
 

--- a/src/lib/finn/extractEnergimerke.test.ts
+++ b/src/lib/finn/extractEnergimerke.test.ts
@@ -1,0 +1,85 @@
+import * as cheerio from "cheerio";
+import { describe, expect, it } from "vitest";
+
+import { extractEnergimerke, extractFromText } from "./extractEnergimerke";
+
+describe("extractEnergimerke — text patterns", () => {
+  it("parses 'Energimerking: A - Mørkegrønn'", () => {
+    expect(extractFromText("Energimerking: A - Mørkegrønn")).toEqual({
+      letter: "A",
+      color: "dark_green",
+    });
+  });
+
+  it("parses real FINN format 'Energimerking: E - Oransje'", () => {
+    expect(extractFromText("Energimerking: E - Oransje")).toEqual({
+      letter: "E",
+      color: "orange",
+    });
+  });
+
+  it.each([
+    ["B - Lysegrønn", "B", "light_green"],
+    ["C - Gul", "C", "yellow"],
+    ["G - Rød", "G", "red"],
+  ])("parses 'Energimerking: %s'", (suffix, letter, color) => {
+    expect(extractFromText(`Energimerking: ${suffix}`)).toEqual({
+      letter,
+      color,
+    });
+  });
+
+  it("returns letter only when color is missing", () => {
+    expect(extractFromText("Energimerking: D")).toEqual({
+      letter: "D",
+      color: null,
+    });
+  });
+
+  it("ignores 'Energimerking' followed by descriptive text (no rating)", () => {
+    // FINN sometimes shows the heading "Energimerking" above an explanatory
+    // paragraph "Energiattesten utgjør…" — the negative lookahead must
+    // prevent matching the leading 'E' of "Energiattesten".
+    const text =
+      "Energimerking\nEnergiattesten utgjør en del av informasjonen kjøper får.";
+    expect(extractFromText(text)).toEqual({ letter: null, color: null });
+  });
+
+  it("returns nulls when no Energimerking text present", () => {
+    expect(extractFromText("Random unrelated content")).toEqual({
+      letter: null,
+      color: null,
+    });
+  });
+
+  it("accepts English snake_case color words as a fallback", () => {
+    expect(extractFromText("Energimerking: B - light_green")).toEqual({
+      letter: "B",
+      color: "light_green",
+    });
+  });
+
+  it("returns letter + null color when color word is unrecognized", () => {
+    expect(extractFromText("Energimerking: F - bluebellish")).toEqual({
+      letter: "F",
+      color: null,
+    });
+  });
+});
+
+describe("extractEnergimerke — DOM", () => {
+  it("scans body text via Cheerio root", () => {
+    const $ = cheerio.load(
+      `<html><body><section><p>Energimerking: B - Lysegrønn</p></section></body></html>`,
+    );
+    expect(extractEnergimerke($)).toEqual({
+      letter: "B",
+      color: "light_green",
+    });
+  });
+
+  it("returns nulls when body lacks any Energimerking marker", () => {
+    const $ = cheerio.load(`<html><body><h1>Storgata 1</h1></body></html>`);
+    expect(extractEnergimerke($)).toEqual({ letter: null, color: null });
+  });
+});

--- a/src/lib/finn/extractEnergimerke.ts
+++ b/src/lib/finn/extractEnergimerke.ts
@@ -1,0 +1,52 @@
+import type * as cheerio from "cheerio";
+
+import type { EnergimerkeColor, EnergimerkeLetter } from "./types";
+
+export interface EnergimerkeResult {
+  letter: EnergimerkeLetter | null;
+  color: EnergimerkeColor | null;
+}
+
+const NORWEGIAN_TO_COLOR: Record<string, EnergimerkeColor> = {
+  // Norwegian color words FINN renders next to the letter
+  "mørkegrønn": "dark_green",
+  "mørke grønn": "dark_green",
+  "lysegrønn": "light_green",
+  "lyse grønn": "light_green",
+  "gul": "yellow",
+  "oransje": "orange",
+  "rød": "red",
+  // English snake_case fallbacks (in case FINN ever ships them, or future JSON-LD)
+  "dark_green": "dark_green",
+  "light_green": "light_green",
+  "yellow": "yellow",
+  "orange": "orange",
+  "red": "red",
+};
+
+// Match e.g. "Energimerking: E - Oransje" or "Energimerking E" (letter only).
+// The negative lookahead after the letter prevents matching "Energimerking\nEnergiattesten…"
+// where the next char "n" is part of a different word.
+const ENERGIMERKE_RE =
+  /Energimerking[:\s]+([A-G])(?![a-zæøåA-ZÆØÅ])(?:\s*[-–—]\s*([A-Za-zæøåÆØÅ_ ]+))?/u;
+
+export function extractEnergimerke(
+  $: cheerio.CheerioAPI,
+): EnergimerkeResult {
+  // TODO(monitoring): emit a log when body has "Energimerking" but the
+  // regex below returns null — likely indicates FINN changed the format.
+  const text = $("body").text();
+  return extractFromText(text);
+}
+
+export function extractFromText(text: string): EnergimerkeResult {
+  const m = text.match(ENERGIMERKE_RE);
+  if (!m) return { letter: null, color: null };
+  const letter = m[1]!.toUpperCase() as EnergimerkeLetter;
+  let color: EnergimerkeColor | null = null;
+  if (m[2]) {
+    const colorWord = m[2].trim().toLowerCase();
+    color = NORWEGIAN_TO_COLOR[colorWord] ?? null;
+  }
+  return { letter, color };
+}

--- a/src/lib/finn/parse.test.ts
+++ b/src/lib/finn/parse.test.ts
@@ -22,7 +22,8 @@ function loadFixture(name: string): string {
   );
 }
 
-const FAKE_URL = "https://www.finn.no/realestate/homes/ad.html?finnkode=1";
+const FAKE_URL =
+  "https://www.finn.no/realestate/homes/ad.html?finnkode=123456789";
 
 describe("parseFinnHtml — JSON-LD extraction", () => {
   it("extracts every field from a well-formed JSON-LD block", async () => {
@@ -56,8 +57,29 @@ describe("parseFinnHtml — JSON-LD extraction", () => {
         "year_built",
         "property_type",
         "image_url",
+        "felleskostnader",
+        "omkostninger",
+        "fellesgjeld",
+        "etasje",
+        "energimerke_letter",
+        "energimerke_color",
+        "finnkode",
       ]),
     );
+  });
+
+  it("extracts the new budget + energi + finnkode fields", async () => {
+    const html = loadFixture("listing-1.html");
+    const r = await parseFinnHtml(html, FAKE_URL);
+
+    expect(r.felleskostnader).toBe(3_200);
+    expect(r.omkostninger).toBe(148_890);
+    expect(r.fellesgjeld).toBe(119_100);
+    expect(r.etasje).toBe("3");
+    expect(r.energimerke_letter).toBe("B");
+    expect(r.energimerke_color).toBe("light_green");
+    // URL takes precedence over the page label, both 123456789 here.
+    expect(r.finnkode).toBe(123_456_789);
   });
 
   it("ignores non-listing JSON-LD blocks (BreadcrumbList, etc.)", async () => {
@@ -86,6 +108,20 @@ describe("parseFinnHtml — CSS-selector fallback", () => {
       "https://images.finncdn.no/dynamic/example/listing-2.jpg",
     );
   });
+
+  it("extracts new fields from a <th>/<td> table", async () => {
+    const html = loadFixture("listing-2.html");
+    const r = await parseFinnHtml(html, FAKE_URL);
+
+    expect(r.omkostninger).toBe(112_000);
+    expect(r.tomteareal).toBe(865);
+    expect(r.etasje).toBe("U. etasje");
+    expect(r.energimerke_letter).toBe("E");
+    expect(r.energimerke_color).toBe("orange");
+    // listing-2 has no Felleskost/Fellesgjeld rows
+    expect(r.felleskostnader).toBeNull();
+    expect(r.fellesgjeld).toBeNull();
+  });
 });
 
 describe("parseFinnHtml — partial extraction", () => {
@@ -104,9 +140,34 @@ describe("parseFinnHtml — partial extraction", () => {
     expect(r.bathrooms).toBeNull();
     expect(r.primary_rooms).toBeNull();
     expect(r.property_type).toBeNull();
+    // New fields are also null when neither label nor energi text is present.
+    expect(r.felleskostnader).toBeNull();
+    expect(r.omkostninger).toBeNull();
+    expect(r.fellesgjeld).toBeNull();
+    expect(r.tomteareal).toBeNull();
+    expect(r.etasje).toBeNull();
+    expect(r.energimerke_letter).toBeNull();
+    expect(r.energimerke_color).toBeNull();
     expect(r.extracted_fields).toEqual(
       expect.arrayContaining(["address", "image_url"]),
     );
+    // finnkode comes from the URL even on a near-empty page.
+    expect(r.finnkode).toBe(123_456_789);
+    expect(r.extracted_fields).toContain("finnkode");
+  });
+
+  it("falls back from URL to page text when finnkode is not in the URL", async () => {
+    const html = loadFixture("listing-1.html");
+    const noQueryUrl = "https://www.finn.no/realestate/homes/ad.html";
+    const r = await parseFinnHtml(html, noQueryUrl);
+    // listing-1 has <dt>FINN-kode</dt><dd>123456789</dd>
+    expect(r.finnkode).toBe(123_456_789);
+  });
+
+  it("returns null finnkode when URL is opaque and page lacks it", async () => {
+    const r = await parseFinnHtml("<html><body></body></html>", "not-a-url");
+    expect(r.finnkode).toBeNull();
+    expect(r.extracted_fields).not.toContain("finnkode");
   });
 });
 
@@ -114,7 +175,8 @@ describe("parseFinnHtml — robustness", () => {
   it("does not throw on garbage input", async () => {
     const r = await parseFinnHtml("not really html", FAKE_URL);
     expect(r.finn_link).toBe(FAKE_URL);
-    expect(r.extracted_fields).toEqual([]);
+    // finnkode is URL-derived, so it survives garbage HTML.
+    expect(r.extracted_fields).toEqual(["finnkode"]);
   });
 
   it("does not throw on malformed JSON-LD", async () => {
@@ -130,7 +192,8 @@ describe("parseFinnHtml — robustness", () => {
 
   it("handles empty html", async () => {
     const r = await parseFinnHtml("", FAKE_URL);
-    expect(r.extracted_fields).toEqual([]);
+    // finnkode is URL-derived, so empty HTML still yields one extracted key.
+    expect(r.extracted_fields).toEqual(["finnkode"]);
     expect(r.finn_link).toBe(FAKE_URL);
   });
 });

--- a/src/lib/finn/parse.ts
+++ b/src/lib/finn/parse.ts
@@ -1,5 +1,6 @@
 import * as cheerio from "cheerio";
 
+import { extractEnergimerke } from "./extractEnergimerke";
 import type { ParsedListing, ParsedListingKey } from "./types";
 
 /**
@@ -27,6 +28,7 @@ export async function parseFinnHtml(
 ): Promise<ParsedListing> {
   const $ = cheerio.load(html);
   const fromJsonLd = extractFromJsonLd($);
+  const energimerke = extractEnergimerke($);
   const merged: Omit<ParsedListing, "extracted_fields" | "finn_link"> = {
     address: fromJsonLd.address ?? extractAddress($),
     price: fromJsonLd.price ?? extractPrice($),
@@ -37,6 +39,14 @@ export async function parseFinnHtml(
     year_built: fromJsonLd.year_built ?? extractYearBuilt($),
     property_type: fromJsonLd.property_type ?? extractPropertyType($),
     image_url: fromJsonLd.image_url ?? extractImageUrl($),
+    felleskostnader: extractFelleskostnader($),
+    omkostninger: extractOmkostninger($),
+    fellesgjeld: extractFellesgjeld($),
+    tomteareal: extractTomteareal($),
+    etasje: extractEtasje($),
+    energimerke_letter: energimerke.letter,
+    energimerke_color: energimerke.color,
+    finnkode: extractFinnkode($, finnLink),
   };
 
   const extracted_fields = (
@@ -318,6 +328,87 @@ function extractImageUrl($: cheerio.CheerioAPI): string | null {
   // First gallery image, fallback.
   const firstImg = $('img[src^="https://"]').first().attr("src");
   return firstImg ?? null;
+}
+
+// TODO(monitoring): if these label-based extractors return null on a high
+// proportion of FINN imports, FINN may have renamed the labels — log and
+// add the new alias to the relevant `findLabelledValue` candidates.
+
+function extractFelleskostnader($: cheerio.CheerioAPI): number | null {
+  const v = findLabelledValue($, [
+    "Felleskost/mnd.",
+    "Felleskost/mnd",
+    "Felleskostnader",
+    "Felleskost",
+  ]);
+  return v ? parseNorwegianInt(v) : null;
+}
+
+function extractOmkostninger($: cheerio.CheerioAPI): number | null {
+  const v = findLabelledValue($, ["Omkostninger"]);
+  return v ? parseNorwegianInt(v) : null;
+}
+
+function extractFellesgjeld($: cheerio.CheerioAPI): number | null {
+  const v = findLabelledValue($, ["Fellesgjeld", "Andel fellesgjeld"]);
+  return v ? parseNorwegianInt(v) : null;
+}
+
+function extractTomteareal($: cheerio.CheerioAPI): number | null {
+  const v = findLabelledValue($, ["Tomteareal"]);
+  if (!v) return null;
+  // FINN renders "865 m² (eiet)" — parseSquareMeters grabs the leading
+  // numeric chunk and ignores the suffix. Truncate to int per schema.
+  const n = parseSquareMeters(v);
+  return n == null ? null : Math.trunc(n);
+}
+
+function extractEtasje($: cheerio.CheerioAPI): string | null {
+  const v = findLabelledValue($, ["Etasje"]);
+  if (!v) return null;
+  const trimmed = v.trim();
+  if (!trimmed) return null;
+  // Schema CHECK enforces ≤20 chars; truncate defensively so a freak FINN
+  // value never blocks the insert.
+  return trimmed.length > 20 ? trimmed.slice(0, 20) : trimmed;
+}
+
+function extractFinnkode(
+  $: cheerio.CheerioAPI,
+  finnLink: string,
+): number | null {
+  // Strategy 1: parse the URL query string. This is the canonical source
+  // and works even when the page failed to fetch the full body.
+  try {
+    const url = new URL(finnLink);
+    const fromQuery = url.searchParams.get("finnkode");
+    if (fromQuery) {
+      const n = parseInt(fromQuery, 10);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+  } catch {
+    // fall through to text-based extraction
+  }
+
+  // Strategy 2: the "FINN-kode" label appears in the Annonseinformasjon
+  // section near the bottom of every ad page.
+  const labelled = findLabelledValue($, ["FINN-kode", "Finn-kode", "Finnkode"]);
+  if (labelled) {
+    const n = parseInt(labelled.replace(/[^\d]/g, ""), 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+
+  // Strategy 3: scan body text for `finnkode=<digits>` (covers cases
+  // where the label is missing but a finnkode appears elsewhere).
+  const bodyMatch = $("body")
+    .text()
+    .match(/finnkode[=:\s]+(\d{4,})/i);
+  if (bodyMatch) {
+    const n = parseInt(bodyMatch[1]!, 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+
+  return null;
 }
 
 /**

--- a/src/lib/finn/types.ts
+++ b/src/lib/finn/types.ts
@@ -10,6 +10,17 @@
  * with an `extracted_fields` array reflecting what was actually found.
  */
 
+/** Allowed energimerke letters. */
+export type EnergimerkeLetter = "A" | "B" | "C" | "D" | "E" | "F" | "G";
+
+/** Allowed energimerke colors (matches the schema CHECK constraint). */
+export type EnergimerkeColor =
+  | "dark_green"
+  | "light_green"
+  | "yellow"
+  | "orange"
+  | "red";
+
 /** Fields the parser tries to populate from a FINN listing. */
 export interface ParsedListing {
   address: string | null;
@@ -23,6 +34,20 @@ export interface ParsedListing {
   year_built: number | null;
   property_type: string | null;
   image_url: string | null;
+  /** Felleskostnader (NOK / month). */
+  felleskostnader: number | null;
+  /** Omkostninger (NOK, one-time). */
+  omkostninger: number | null;
+  /** Fellesgjeld / andel fellesgjeld (NOK). */
+  fellesgjeld: number | null;
+  /** Tomteareal (m²). */
+  tomteareal: number | null;
+  /** Etasje — verbatim text (e.g. "1", "U. etasje", "Loft"); ≤ 20 chars. */
+  etasje: string | null;
+  energimerke_letter: EnergimerkeLetter | null;
+  energimerke_color: EnergimerkeColor | null;
+  /** FINN listing id (numeric), parsed from URL or page text. */
+  finnkode: number | null;
   /** The original FINN URL — echoed back so the client doesn't re-derive. */
   finn_link: string;
   /**
@@ -42,7 +67,15 @@ export type ParsedListingKey =
   | "bathrooms"
   | "year_built"
   | "property_type"
-  | "image_url";
+  | "image_url"
+  | "felleskostnader"
+  | "omkostninger"
+  | "fellesgjeld"
+  | "tomteareal"
+  | "etasje"
+  | "energimerke_letter"
+  | "energimerke_color"
+  | "finnkode";
 
 /** Discriminated union returned by the route handler. */
 export type ParseResult =

--- a/supabase/migrations/20260503000004_properties_finn_fields.sql
+++ b/supabase/migrations/20260503000004_properties_finn_fields.sql
@@ -1,0 +1,102 @@
+-- properties — extend with budget + energi + finnkode columns.
+--
+-- Owned by the `properties-finn-fields` capability. Adds eight nullable
+-- columns sourced from FINN listings (or filled in manually): three
+-- cost numbers, the plot size, the floor label, the energy rating
+-- (letter + color), and the FINN listing id.
+--
+-- Idempotent so the migration is safe to re-run on environments that
+-- already pulled the columns in via an earlier branch.
+--
+-- Spec: openspec/changes/properties-finn-fields/specs/properties-finn-fields/spec.md
+-- Design: openspec/changes/properties-finn-fields/design.md (D1, D2, D3, D4)
+
+-- 1. Columns ------------------------------------------------------------------
+
+alter table public.properties
+    add column if not exists felleskostnader integer,
+    add column if not exists omkostninger integer,
+    add column if not exists fellesgjeld integer,
+    add column if not exists tomteareal integer,
+    add column if not exists etasje text,
+    add column if not exists energimerke_letter char(1),
+    add column if not exists energimerke_color text,
+    add column if not exists finnkode integer;
+
+comment on column public.properties.felleskostnader is
+    'Felleskostnader per måned (NOK). Nullable.';
+comment on column public.properties.omkostninger is
+    'Omkostninger ved kjøp (NOK, engang). Nullable.';
+comment on column public.properties.fellesgjeld is
+    'Andel fellesgjeld (NOK). Nullable.';
+comment on column public.properties.tomteareal is
+    'Tomteareal (m²). Nullable.';
+comment on column public.properties.etasje is
+    'Etasje som tekst — FINN bruker varianter ("4. etasje", "U. etasje", '
+    '"1. av 5"). Maks 20 tegn. Nullable.';
+comment on column public.properties.energimerke_letter is
+    'Energimerke A–G. Nullable.';
+comment on column public.properties.energimerke_color is
+    'Energimerke fargekode (dark_green/light_green/yellow/orange/red). Nullable.';
+comment on column public.properties.finnkode is
+    'FINN-annonsens id. Tillater dedupe per husholdning via partial unique index. Nullable.';
+
+-- 2. CHECK constraints --------------------------------------------------------
+--
+-- Wrapped in DO-blocks so the migration is idempotent. Postgres < 16
+-- has no `add constraint if not exists` so we look it up in
+-- pg_constraint by name first.
+
+do $$
+begin
+    if not exists (
+        select 1 from pg_constraint
+        where conname = 'properties_energimerke_letter_check'
+          and conrelid = 'public.properties'::regclass
+    ) then
+        alter table public.properties
+            add constraint properties_energimerke_letter_check
+            check (energimerke_letter is null
+                   or energimerke_letter in ('A','B','C','D','E','F','G'));
+    end if;
+end$$;
+
+do $$
+begin
+    if not exists (
+        select 1 from pg_constraint
+        where conname = 'properties_energimerke_color_check'
+          and conrelid = 'public.properties'::regclass
+    ) then
+        alter table public.properties
+            add constraint properties_energimerke_color_check
+            check (energimerke_color is null
+                   or energimerke_color in (
+                       'dark_green', 'light_green', 'yellow', 'orange', 'red'
+                   ));
+    end if;
+end$$;
+
+do $$
+begin
+    if not exists (
+        select 1 from pg_constraint
+        where conname = 'properties_etasje_length_check'
+          and conrelid = 'public.properties'::regclass
+    ) then
+        alter table public.properties
+            add constraint properties_etasje_length_check
+            check (etasje is null or length(etasje) <= 20);
+    end if;
+end$$;
+
+-- 3. Partial unique index on (household_id, finnkode) -------------------------
+--
+-- Per-household uniqueness so two unrelated households can score the
+-- same listing, but the same household can't add it twice. Partial
+-- WHERE excludes nulls so manually-entered properties (no finnkode)
+-- can coexist freely.
+
+create unique index if not exists properties_household_finnkode_uniq
+    on public.properties (household_id, finnkode)
+    where finnkode is not null;

--- a/tests/fixtures/finn/listing-1.html
+++ b/tests/fixtures/finn/listing-1.html
@@ -60,17 +60,26 @@
       <dl>
         <dt>Prisantydning</dt>
         <dd>5 250 000 kr</dd>
-        <dt>Felleskostnader</dt>
-        <dd>3 200 kr/mnd</dd>
+        <dt>Felleskost/mnd.</dt>
+        <dd>3 200 kr</dd>
+        <dt>Omkostninger</dt>
+        <dd>148 890 kr</dd>
+        <dt>Fellesgjeld</dt>
+        <dd>119 100 kr</dd>
         <dt>Boligtype</dt>
         <dd>Leilighet</dd>
         <dt>Bruksareal</dt>
         <dd>72,5 m²</dd>
         <dt>Soverom</dt>
         <dd>2</dd>
+        <dt>Etasje</dt>
+        <dd>3</dd>
         <dt>Byggeår</dt>
         <dd>1932</dd>
+        <dt>FINN-kode</dt>
+        <dd>123456789</dd>
       </dl>
+      <p>Energimerking: B - Lysegrønn</p>
     </section>
   </body>
 </html>

--- a/tests/fixtures/finn/listing-2.html
+++ b/tests/fixtures/finn/listing-2.html
@@ -18,14 +18,19 @@
       <table>
         <tbody>
           <tr><th>Prisantydning</th><td>3 950 000,-</td></tr>
+          <tr><th>Omkostninger</th><td>112 000 kr</td></tr>
           <tr><th>Boligtype</th><td>Enebolig</td></tr>
           <tr><th>Bruksareal</th><td>120 m²</td></tr>
           <tr><th>Primærrom</th><td>110 m²</td></tr>
+          <tr><th>Tomteareal</th><td>865 m² (eiet)</td></tr>
+          <tr><th>Etasje</th><td>U. etasje</td></tr>
           <tr><th>Soverom</th><td>4</td></tr>
           <tr><th>Bad</th><td>2</td></tr>
           <tr><th>Byggeår</th><td>1985</td></tr>
+          <tr><th>FINN-kode</th><td>987654321</td></tr>
         </tbody>
       </table>
+      <p>Energimerking: E - Oransje</p>
     </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- **Spec-only** for now. Adds the openspec scaffolding (`proposal.md`, `design.md`, `specs/properties-finn-fields/spec.md`, `tasks.md`) for extending properties with budget + energi facts.
- 8 nullable columns: `felleskostnader`, `omkostninger`, `fellesgjeld`, `tomteareal`, `etasje` (text), `energimerke_letter`, `energimerke_color`, `finnkode`. Partial unique index on `(household_id, finnkode)`.
- Parser populates all 8 best-effort; pre-parse dedupe rejects re-imports per household with a deep link to the existing property.
- UI: Kostnader/Energi inputs in NyBoligForm, Kostnader card on Oversikt, single `felleskostnader` line on PropertyCard (rest stays on detail view per direction "keep cards simple").

## Locked decisions
- `etasje` stored as text (FINN ships strings like `"4. etasje"`, `"U. etasje"`).
- Energimerke split into letter + color columns with CHECK constraints.
- finnkode unique per household via partial index (`WHERE finnkode IS NOT NULL`).
- PropertyCard adds only `felleskostnader`; everything else stays on the Oversikt Kostnader card.

## Test plan
- [ ] Review `proposal.md` and `design.md` for direction
- [ ] Convert tasks.md into actual implementation commits (10 sections, 36 tasks)
- [ ] Migration applies cleanly + seed.sql still loads
- [ ] Parser unit tests against extended fixtures
- [ ] E2E paste-FINN → form prefills new fields → Oversikt shows Kostnader card

🤖 Generated with [Claude Code](https://claude.com/claude-code)