### PR TITLE
fix(households): resolve member names instead of showing user ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "cheerio": "^1.0.0",
         "next": "^14.2.15",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "server-only": "^0.0.1"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.0",
@@ -2432,7 +2433,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2445,7 +2445,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2458,7 +2457,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2471,7 +2469,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2484,7 +2481,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2497,7 +2493,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2510,7 +2505,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2523,7 +2517,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2536,7 +2529,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2549,7 +2541,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2562,7 +2553,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2575,7 +2565,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2588,7 +2577,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2601,7 +2589,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2614,7 +2601,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2627,7 +2613,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2640,7 +2625,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2653,7 +2637,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2666,7 +2649,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2679,7 +2661,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -2692,7 +2673,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openharmony"
@@ -2705,7 +2685,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2718,7 +2697,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2731,7 +2709,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2744,7 +2721,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -8397,6 +8373,12 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "cheerio": "^1.0.0",
     "next": "^14.2.15",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "server-only": "^0.0.1"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.0",

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import { getServiceRoleKey, PUBLIC_SUPABASE_URL } from "@/lib/env";
+
+/**
+ * Service-role Supabase client.
+ *
+ * This key bypasses RLS, so the module is marked `server-only`: importing it
+ * from a client component is a build error rather than a leak. Never pass the
+ * client, or anything derived from it, to the browser.
+ *
+ * Returns `null` when the key is not configured, so callers can degrade
+ * instead of throwing — the same contract `getServiceRoleKey()` offers. Use it
+ * only where a cross-user read is genuinely required and RLS would hide the
+ * row from the signed-in caller; for everything else use the cookie-bound
+ * client from `server.ts`, which keeps RLS in force.
+ *
+ * No session is persisted: this client is request-scoped and must never pick
+ * up or write the caller's auth cookie.
+ */
+export function createSupabaseAdminClient(): SupabaseClient | null {
+  const key = getServiceRoleKey();
+  if (!key || !PUBLIC_SUPABASE_URL) return null;
+
+  return createClient(PUBLIC_SUPABASE_URL, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}

--- a/src/server/households/getHousehold.ts
+++ b/src/server/households/getHousehold.ts
@@ -8,17 +8,17 @@ import type {
 } from "@/lib/households/types";
 import { err, ok } from "@/lib/households/types";
 
+import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+
 import { requireUser } from "./_auth";
 
 /**
  * Fetch a single household plus its member list. RLS guarantees the
  * caller is a member; non-members get a "not found" response.
  *
- * Member email lookups go through Supabase's `auth.admin.getUserById`,
- * which requires the service-role key. In local dev (no service-role
- * configured) we fall back to returning `null` emails — the UI shows
- * the user_id then. This trade-off keeps the action functional in
- * environments without a service-role key.
+ * Member email lookups go through Supabase's `auth.admin.getUserById` on a
+ * service-role client. Without the key the emails come back null and the UI
+ * falls back to the user_id, so the action stays functional either way.
  */
 export async function getHousehold(
   id: string,
@@ -45,25 +45,23 @@ export async function getHousehold(
 
   if (mError) return err(mError.message);
 
-  // Best-effort email enrichment. Service-role key is server-only and
-  // optional in dev; if absent, emails are null.
+  // Best-effort email enrichment. Needs the service-role key: `auth.admin`
+  // is an admin API, and the cookie-bound anon client this action otherwise
+  // uses can never satisfy it. When the key is absent the emails stay null
+  // and the UI falls back to the user_id, which keeps this action working in
+  // environments without one.
+  const admin = createSupabaseAdminClient();
+
   const members = await Promise.all(
     (memberRows ?? []).map(async (row) => {
       let email: string | null = null;
-      try {
-        // Cast: auth.admin is only present when the client was built
-        // with a service-role key; the regular cookie-bound client used
-        // here will throw a permission error, which we swallow.
-        const { data } = await (supabase.auth as unknown as {
-          admin: {
-            getUserById(id: string): Promise<{
-              data: { user: { email: string | null } | null };
-            }>;
-          };
-        }).admin.getUserById(row.user_id);
-        email = data?.user?.email ?? null;
-      } catch {
-        email = null;
+      if (admin) {
+        try {
+          const { data } = await admin.auth.admin.getUserById(row.user_id);
+          email = data?.user?.email ?? null;
+        } catch {
+          email = null;
+        }
       }
       return {
         user_id: row.user_id,


### PR DESCRIPTION
Stacked on #17.

Member names render as `00000000…` wherever a household member is named — the comparison column headers, the household page.

This is not missing configuration. `getHousehold` called `supabase.auth.admin.getUserById` on the **cookie-bound anon client**, which can never satisfy an admin API. The call threw, a bare `catch` swallowed it, and the UI fell back to the user_id prefix. `SUPABASE_SERVICE_ROLE_KEY` was read in `env.ts` but never used to build a client, so no code path could have worked — hosted or local.

## Changes

- `src/lib/supabase/admin.ts` — service-role client, returning `null` when the key is absent so the action still degrades gracefully
- `getHousehold` uses it for the email lookup

The module is marked `server-only`, which is the one reason for the new dependency: it makes importing an RLS-bypassing key from a client component a build error rather than a leak. Single file, no transitive deps.

## Validation

Against the local stack:

```
Med service-role-klient (slik koden nå gjør):
  owner  00000000… → alice@test.local
  member 00000000… → bob@test.local

Med anon-klient (slik koden gjorde før):
  → FEIL: User not allowed
```

`npm run typecheck`, `npm run lint`, `npm test` all green (218 passed, 139 skipped).

**Not verified end to end in a browser.** I hit a local session issue where `/dev/login` issues a cookie the middleware then rejects — a direct API sign-in works, so it looks like local auth state rather than app code, but I did not get to the bottom of it and it predates this change. Worth a click-through before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDrprdXBZk43TyMBvz7Q4e